### PR TITLE
Minor changes to the Async typeclass and its instance for cats-effect

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,13 +2,13 @@ import Dependencies._
 import xerial.sbt.Sonatype._
 import ReleaseTransformations._
 
-val neo4jDriverVersion = "1.7.2"
+val neo4jDriverVersion = "1.7.3"
 val shapelessVersion = "2.3.3"
 val testcontainersScalaVersion = "0.23.0"
 val mockitoVersion = "1.10.19"
 val scalaTestVersion = "3.0.5"
 val slf4jVersion = "1.7.21"
-val catsEffectsVersion = "1.1.0"
+val catsEffectsVersion = "1.2.0"
 val monixVersion = "3.0.0-RC2"
 val akkaStreamVersion = "2.5.19"
 

--- a/cats-effect/src/main/scala/neotypes/cats/CatsAsync.scala
+++ b/cats-effect/src/main/scala/neotypes/cats/CatsAsync.scala
@@ -3,20 +3,25 @@ package neotypes.cats
 import cats.{ApplicativeError, effect}
 import neotypes.Async
 
-class CatsAsync[F[_]](implicit e: effect.Async[F], ae: ApplicativeError[F, Throwable]) extends Async[F] {
+class CatsAsync[F[_]](implicit F: effect.Async[F]) extends Async[F] {
 
-  override def async[T](cb: (Either[Throwable, T] => Unit) => Unit): F[T] = e.async(cb)
+  override def async[T](cb: (Either[Throwable, T] => Unit) => Unit): F[T] =
+    F.async(cb)
 
-  override def flatMap[T, U](m: F[T])(f: T => F[U]): F[U] = e.flatMap(m)(f)
+  override def flatMap[T, U](m: F[T])(f: T => F[U]): F[U] =
+    F.flatMap(m)(f)
 
-  override def map[T, U](m: F[T])(f: T => U): F[U] = e.map(m)(f)
+  override def map[T, U](m: F[T])(f: T => U): F[U] =
+    F.map(m)(f)
 
   override def recoverWith[T, U >: T](m: F[T])(f: PartialFunction[Throwable, F[U]]): F[U] =
-    e.recoverWith(m)(f.asInstanceOf[PartialFunction[Throwable, F[T]]]).asInstanceOf[F[U]]
+    F.recoverWith(F.map(m)(identity): F[U])(f)
 
-  override def failed[T](e: Throwable): F[T] = ae.raiseError(e)
+  override def failed[T](e: Throwable): F[T] =
+    F.raiseError(e)
 
-  override def success[T](t: => T): F[T] = e.delay(t)
+  override def success[T](t: => T): F[T] =
+    F.delay(t)
 }
 
 object implicits {

--- a/core/src/main/scala/neotypes/Async.scala
+++ b/core/src/main/scala/neotypes/Async.scala
@@ -19,12 +19,15 @@ trait Async[F[_]] {
 
 object Async {
 
-  implicit class AsyncExt[F[_], T](m: F[T])(implicit F: Async[F]) {
-    def map[U](f: T => U) = F.map(m)(f)
+  implicit class AsyncExt[F[_], T](val m: F[T]) extends AnyVal {
+    def map[U](f: T => U)(implicit F: Async[F]): F[U] =
+      F.map(m)(f)
 
-    def flatMap[U](f: T => F[U]) = F.flatMap(m)(f)
+    def flatMap[U](f: T => F[U])(implicit F: Async[F]): F[U] =
+      F.flatMap(m)(f)
 
-    def recoverWith[U >: T](f: PartialFunction[Throwable, F[U]]): F[U] = F.recoverWith[T, U](m)(f)
+    def recoverWith[U >: T](f: PartialFunction[Throwable, F[U]])(implicit F: Async[F]): F[U] =
+      F.recoverWith[T, U](m)(f)
   }
 
   class FutureAsync(implicit ec: ExecutionContext) extends Async[Future] {

--- a/core/src/main/scala/neotypes/exceptions/Exception.scala
+++ b/core/src/main/scala/neotypes/exceptions/Exception.scala
@@ -1,4 +1,4 @@
-package neotypes.excpetions
+package neotypes.exceptions
 
 import org.neo4j.driver.v1.exceptions.value.Uncoercible
 

--- a/core/src/main/scala/neotypes/implicits/implicits.scala
+++ b/core/src/main/scala/neotypes/implicits/implicits.scala
@@ -3,7 +3,7 @@ package neotypes
 import java.time.{LocalDate, LocalDateTime, LocalTime}
 
 import neotypes.DeferredQueryBuilder.Part
-import neotypes.excpetions.{ConversionException, PropertyNotFoundException, UncoercibleException}
+import neotypes.exceptions.{ConversionException, PropertyNotFoundException, UncoercibleException}
 import neotypes.types._
 import neotypes.utils.FunctionUtils._
 import neotypes.mappers.{ValueMapper, _}

--- a/core/src/test/scala/neotypes/BasicSessionSpec.scala
+++ b/core/src/test/scala/neotypes/BasicSessionSpec.scala
@@ -48,8 +48,8 @@ class BasicSessionSpec extends AsyncFlatSpec with BaseIntegrationSpec {
       assert(map("born").asInt == 1975)
       assert(emptyResult.isEmpty)
       assert(emptyResultList.isEmpty)
-      assert(emptyResultEx == "neotypes.excpetions.PropertyNotFoundException: Property  not found") // TODO test separately
-      assert(notString == "neotypes.excpetions.UncoercibleException: Cannot coerce INTEGER to Java String") // TODO test separately
+      assert(emptyResultEx == "neotypes.exceptions.PropertyNotFoundException: Property  not found") // TODO test separately
+      assert(notString == "neotypes.exceptions.UncoercibleException: Cannot coerce INTEGER to Java String") // TODO test separately
 
     }
   }


### PR DESCRIPTION
Basically I just:

+ Bump up the cats-effect and the Neo4j java driver _dependencies_.
+ Made the `AsyncExt` **implicit class** a **value class** too.
+ Remove the unnecessary `ApplicativeError[F, Throwable]` _constraint_ for `CatsAsync` instance.
+ Replaced the _"unsafe"_ typecasts on `CatsAsync.recoverWith` with a _"type-safe"_ identity map.
+ Renamed the `excpetions` package to `exceptions` - _(**Not sure if this change will break someone code, I can revert it if you want**)_.