### PR TITLE
Proposal to simplify calls to the stream method.

### DIFF
--- a/akka-stream/src/main/scala/neotypes/akkastreams/implicits.scala
+++ b/akka-stream/src/main/scala/neotypes/akkastreams/implicits.scala
@@ -5,8 +5,10 @@ import akka.stream.scaladsl.{Flow, Source}
 import scala.concurrent.{ExecutionContext, Future}
 
 object implicits {
-  implicit def akkaStream(implicit ec: ExecutionContext): neotypes.Stream[AkkaStream, Future] =
-    new neotypes.Stream[AkkaStream, Future] {
+  implicit def akkaStream(implicit ec: ExecutionContext): neotypes.Stream.Aux[AkkaStream, Future] =
+    new neotypes.Stream[AkkaStream] {
+      override type F[T] = Future[T]
+
       override def init[T](value: () => Future[Option[T]]): AkkaStream[T] =
         Source
           .repeat(())
@@ -24,5 +26,5 @@ object implicits {
         Source
           .fromFutureSource(f)
           .viaMat(Flow[T]) { (m, _) => m.flatMap(identity) }
-  }
+    }
 }

--- a/akka-stream/src/test/scala/neotypes/akkastreams/AkkaStreamSpec.scala
+++ b/akka-stream/src/test/scala/neotypes/akkastreams/AkkaStreamSpec.scala
@@ -18,8 +18,9 @@ class AkkaStreamSpec extends AsyncFlatSpec with BaseIntegrationSpec {
 
     "match (p:Person) return p.name"
       .query[Int]
-      .stream[AkkaStream, Future](s)
-      .runWith(Sink.seq[Int]).map {
+      .stream[AkkaStream](s)
+      .runWith(Sink.seq[Int])
+      .map {
         names => assert(names == (0 to 10))
       }
   }

--- a/core/src/main/scala/neotypes/DeferredQuery.scala
+++ b/core/src/main/scala/neotypes/DeferredQuery.scala
@@ -95,7 +95,7 @@ private[neotypes] class DeferredQueryBuilder(private val parts: List[DeferredQue
     new DeferredQueryBuilder(this.parts ::: that.parts)
 
   def +(that: String): DeferredQueryBuilder =
-    new DeferredQueryBuilder(this.parts :+ Query(that)
+    new DeferredQueryBuilder(this.parts :+ Query(that))
 }
 
 private[neotypes] object DeferredQueryBuilder {

--- a/core/src/main/scala/neotypes/DeferredQuery.scala
+++ b/core/src/main/scala/neotypes/DeferredQuery.scala
@@ -4,7 +4,9 @@ import neotypes.mappers.{ExecutionMapper, ResultMapper}
 
 import scala.collection.mutable.StringBuilder
 
-final case class DeferredQuery[T](query: String, params: Map[String, Any] = Map.empty) {
+private[neotypes] final case class DeferredQuery[T](query: String, params: Map[String, Any] = Map.empty) {
+  import DeferredQuery.StreamPartiallyApplied
+
   def list[F[_]](session: Session[F])(implicit rm: ResultMapper[T]): F[List[T]] =
     session.transact(tx => list(tx))
 
@@ -13,17 +15,6 @@ final case class DeferredQuery[T](query: String, params: Map[String, Any] = Map.
 
   def execute[F[_]](session: Session[F])(implicit rm: ExecutionMapper[T]): F[T] =
     session.transact(tx => execute(tx))
-
-  def stream[S[_], F[_]](session: Session[F])(implicit rm: ResultMapper[T], sb: Stream[S, F], F: Async[F]): S[T] = {
-    val tx = session.beginTransaction()
-    sb.fToS(
-      F.flatMap(tx) { t =>
-        F.success(
-          sb.onComplete(stream(t))(t.rollback())
-        )
-      }
-    )
-  }
 
   def list[F[_]](tx: Transaction[F])(implicit rm: ResultMapper[T]): F[List[T]] =
     tx.list(query, params)
@@ -34,11 +25,27 @@ final case class DeferredQuery[T](query: String, params: Map[String, Any] = Map.
   def execute[F[_]](tx: Transaction[F])(implicit rm: ExecutionMapper[T]): F[T] =
     tx.execute(query, params)
 
-  def stream[S[_], F[_]](tx: Transaction[F])(implicit rm: ResultMapper[T], sb: Stream[S, F]): S[T] =
-    tx.stream(query, params)
+  def stream[S[_]]: StreamPartiallyApplied[S, T] =
+    new StreamPartiallyApplied[S, T](this)
 
   def withParams(params: Map[String, Any]): DeferredQuery[T] =
-    copy(params = this.params ++ params)
+    this.copy(params = this.params ++ params)
+}
+
+private[neotypes] object DeferredQuery {
+  private[neotypes] final class StreamPartiallyApplied[S[_], T](val dq: DeferredQuery[T]) extends AnyVal {
+    def apply[F[_]](session: Session[F])(implicit rm: ResultMapper[T], S: Stream.Aux[S, F], F: Async[F]): S[T] =
+      S.fToS(
+        F.flatMap(session.beginTransaction()) { tx =>
+          F.success(
+            S.onComplete(tx.stream(dq.query, dq.params))(tx.rollback())
+          )
+        }
+      )
+
+    def apply[F[_]](tx: Transaction[F])(implicit rm: ResultMapper[T], S: Stream.Aux[S, F]): S[T] =
+      tx.stream(dq.query, dq.params)
+  }
 }
 
 private[neotypes] class DeferredQueryBuilder(private val parts: List[DeferredQueryBuilder.Part]) {
@@ -85,9 +92,7 @@ private[neotypes] class DeferredQueryBuilder(private val parts: List[DeferredQue
   }
 
   def +(that: DeferredQueryBuilder): DeferredQueryBuilder =
-    new DeferredQueryBuilder(
-      this.parts ::: that.parts
-    )
+    new DeferredQueryBuilder(this.parts ::: that.parts)
 }
 
 private[neotypes] object DeferredQueryBuilder {

--- a/core/src/main/scala/neotypes/DeferredQuery.scala
+++ b/core/src/main/scala/neotypes/DeferredQuery.scala
@@ -93,6 +93,9 @@ private[neotypes] class DeferredQueryBuilder(private val parts: List[DeferredQue
 
   def +(that: DeferredQueryBuilder): DeferredQueryBuilder =
     new DeferredQueryBuilder(this.parts ::: that.parts)
+
+  def +(that: String): DeferredQueryBuilder =
+    new DeferredQueryBuilder(this.parts :+ Query(that)
 }
 
 private[neotypes] object DeferredQueryBuilder {

--- a/core/src/main/scala/neotypes/Stream.scala
+++ b/core/src/main/scala/neotypes/Stream.scala
@@ -1,9 +1,15 @@
 package neotypes
 
-trait Stream[S[_], F[_]] {
+trait Stream[S[_]] {
+  type F[T]
+
   def init[T](value: () => F[Option[T]]): S[T]
 
   def onComplete[T](s: S[T])(f: => F[Unit]): S[T]
 
   def fToS[T](f: F[S[T]]): S[T]
+}
+
+object Stream {
+  type Aux[S[_], _F[_]] = Stream[S] { type F[T] = _F[T] }
 }

--- a/core/src/main/scala/neotypes/Transaction.scala
+++ b/core/src/main/scala/neotypes/Transaction.scala
@@ -94,7 +94,7 @@ final class Transaction[F[_]](transaction: NTransaction)(implicit F: Async[F]) {
     }
 
   def stream[T: ResultMapper, S[_]](query: String, params: Map[String, Any] = Map.empty)
-                                   (implicit S: Stream[S, F]): S[T] =
+                                   (implicit S: Stream.Aux[S, F]): S[T] =
     S.fToS(
       F.async { cb =>
         transaction

--- a/core/src/main/scala/neotypes/implicits.scala
+++ b/core/src/main/scala/neotypes/implicits.scala
@@ -418,8 +418,10 @@ object implicits {
       new Driver[F](driver)
   }
 
-  implicit def String2QueryBuilder(query: String): DeferredQueryBuilder =
-    new DeferredQueryBuilder(List(DeferredQueryBuilder.Query(query)))
+  implicit class StringOps(val s: String) extends AnyVal {
+    def query[T]: DeferredQuery[T] =
+      DeferredQuery(query = s)
+  }
 
   implicit class CypherString(val sc: StringContext) extends AnyVal {
     def c(args: Any*): DeferredQueryBuilder = {

--- a/docs/src/main/tut/docs.md
+++ b/docs/src/main/tut/docs.md
@@ -13,9 +13,10 @@ title: "Documentation"
 
 ## Session creation
 
-`neotypes` adds an extension method (`.asScala[F[_]: Async]`) to `org.neo4j.driver.v1.Session` and `org.neo4j.driver.v1.Driver` that allows to build a `neotypes`'s session and driver wrappers. You can
-parametrize `asScala` by any type that you have a typeclass `neotypes.Async` implementation for. The typeclass implementation for `scala.concurrent.Future` is 
-built-in (Please read more about [side effect implementations][alternative_effects.html]). Please note that you have to make sure that the session is properly closed at the end of the application execution if you decide to manage session lifecycle manually.
+**neotypes** adds an extension method (`.asScala[F[_]: Async]`) to `org.neo4j.driver.v1.Session` and `org.neo4j.driver.v1.Driver` that allows to build a `neotypes`'s session and driver wrappers.
+You can parametrize `asScala` by any type that you have a typeclass `neotypes.Async` implementation for.
+The typeclass implementation for `scala.concurrent.Future` is built-in (Please read more about [side effect implementations](alternative_effects.html)).
+Please note that you have to make sure that the session is properly closed at the end of the application execution if you decide to manage session lifecycle manually.
 
 ```scala
 val driver = GraphDatabase.driver("bolt://localhost:7687", AuthTokens.basic("neo4j", "****"))
@@ -28,7 +29,7 @@ Please note that the session should be closed to make sure all resources (such a
 session.close()
 ```
 
-or you may decide to use `neotypes.Driver` to help you with it.
+Or you may decide to use `neotypes.Driver` to help you with it.
 
 ```scala
 val driver = GraphDatabase.driver("bolt://localhost:7687", AuthTokens.basic("neo4j", "****")).asScala[Future]
@@ -39,12 +40,14 @@ val result: Future[Seq[Movie]] = driver.readSession { session =>
         RETURN movie""".query[Movie].list(session)
   }
 ```
+
 In this case, the session will be properly closed after query execution.
 
 ## Query execution
 
-Once you have a session constructed, you can start querying the database. The import `neotypes.implicits._` adds an extension method `query[T]` to each
-string literal in its scope or you can use string interpolation. Type parameter `[T]` specifies a resulted return type.
+Once you have a session constructed, you can start querying the database.
+The import `neotypes.implicits._` adds an extension method `query[T]` to each string literal in its scopei, or you can use string interpolation.
+Type parameter `[T]` specifies a resulted return type.
 
 ```scala
 "create (p:Person {name: $name, born: $born})".query[Unit].execute(s)
@@ -54,11 +57,14 @@ val name = "John"
 val born = 1980
 c"create (p:Person {name: $name, born: $born})".query[Unit].execute(s) // Query with string interpolation
 ```
+
 A query can be run in three different ways:
-* `execute(s)` - executes a query that has no return data. Query can be parametrized by `org.neo4j.driver.v1.summary.ResultSummary` or `Unit`. If you need to support your return types for this 
-type of queries, you can provide an implementation of `ExecutionMapper` for any custom type.
-* `single(s)` - runs a query and return single result.
-* `list(s)` - runs a query and returns list of results. 
+
+* `execute(s)` - executes a query that has no return data. Query can be parametrized by `org.neo4j.driver.v1.summary.ResultSummary` or `Unit`.
+If you need to support your return types for this type of queries, you can provide an implementation of `ExecutionMapper` for any custom type.
+* `single(s)` - runs a query and return a single result.
+* `list(s)` - runs a query and returns a list of results.
+* `set(s)` - runs a query and returns a set of results.
 
 ```scala
 // execute
@@ -73,4 +79,8 @@ type of queries, you can provide an implementation of `ExecutionMapper` for any 
 // list
 "match (p:Person {name: 'Charlize Theron'})-[]->(m:Movie) return p,m".query[Person :: Movie :: HNil].list(s)
 "match (p:Person {name: 'Charlize Theron'})-[]->(m:Movie) return p,m".query[(Person, Movie)].list(s)
+
+// set
+"match (p:Person {name: 'Charlize Theron'})-[]->(m:Movie) return p,m".query[Person :: Movie :: HNil].set(s)
+"match (p:Person {name: 'Charlize Theron'})-[]->(m:Movie) return p,m".query[(Person, Movie)].set(s)
 ```

--- a/docs/src/main/tut/docs/types.md
+++ b/docs/src/main/tut/docs/types.md
@@ -36,4 +36,4 @@ title: "Supported types"
 | `User defined case class               `  | ✓              |                       ||
 
 * `*` - `None` is converted into `null`
-* `**` - scala.Map[String, Any]
+* `**` - `scala.Map[String, Any]`

--- a/fs2-stream/src/main/scala/neotypes/fs2/implicits.scala
+++ b/fs2-stream/src/main/scala/neotypes/fs2/implicits.scala
@@ -1,8 +1,10 @@
 package neotypes.fs2
 
 object implicits {
-  implicit def fs2Stream[F[_]](implicit F: cats.effect.Sync[F]): neotypes.Stream[Fs2FStream[F]#T, F] =
-    new neotypes.Stream[Fs2FStream[F]#T, F] {
+  implicit def fs2Stream[_F[_]](implicit F: cats.effect.Sync[_F]): neotypes.Stream.Aux[Fs2FStream[_F]#T, _F] =
+    new neotypes.Stream[Fs2FStream[_F]#T] {
+      override type F[T] = _F[T]
+
       override def init[T](value: () => F[Option[T]]): fs2.Stream[F, T] =
         fs2.Stream.repeatEval(F.suspend(value())).unNoneTerminate
 

--- a/fs2-stream/src/main/scala/neotypes/fs2/implicits.scala
+++ b/fs2-stream/src/main/scala/neotypes/fs2/implicits.scala
@@ -9,7 +9,7 @@ object implicits {
         fs2.Stream.repeatEval(F.suspend(value())).unNoneTerminate
 
       override def onComplete[T](s: fs2.Stream[F, T])(f: => F[Unit]): fs2.Stream[F, T] =
-        s ++ fs2.Stream.eval_(f)
+        s.onFinalize(f)
 
       override def fToS[T](f: F[fs2.Stream[F, T]]): fs2.Stream[F, T] =
         fs2.Stream.eval(f).flatten

--- a/fs2-stream/src/test/scala/neotypes/fs2/Fs2StreamSpec.scala
+++ b/fs2-stream/src/test/scala/neotypes/fs2/Fs2StreamSpec.scala
@@ -13,7 +13,7 @@ class Fs2StreamSpec extends AsyncFlatSpec with BaseIntegrationSpec {
 
     "match (p:Person) return p.name"
       .query[Int]
-      .stream[Fs2IoStream, IO](s)
+      .stream[Fs2IoStream](s)
       .compile
       .toList
       .unsafeToFuture()


### PR DESCRIPTION
IMHO, it was very annoying to specify both, the **Stream** _(`S[_]`)_ and the **Effect** _(`F[_
`)_ type parameters, when calling the `stream` method on a query.
Especially because, always the **Stream** implied the **Effect**. Thus, it was kind of redundant.

So, somewhat inspired by the [**Partially-Applied Type**](https://typelevel.org/cats/guidelines.html) and the [**Aux**](http://gigiigig.github.io/posts/2015/09/13/aux-pattern.html) _patterns_, I come up with this proposal.

Looking forward to your comments.