### PR TITLE
Monix Stream

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,8 @@ lazy val root = (project in file("."))
     catsEffect,
     monix,
     akkaStream,
-    fs2Stream
+    fs2Stream,
+    monixStream
   )
   .settings(noPublishSettings)
   .settings(
@@ -107,7 +108,7 @@ lazy val monix = (project in file("monix"))
   .settings(
     name := "neotypes-monix",
     libraryDependencies ++= PROVIDED(
-      "io.monix" %% "monix" % monixVersion
+      "io.monix" %% "monix-eval" % monixVersion
     )
   )
 
@@ -130,6 +131,18 @@ lazy val fs2Stream = (project in file("fs2-stream"))
     libraryDependencies ++= PROVIDED(
       "org.typelevel" %% "cats-effect" % catsEffectsVersion,
       "co.fs2" %% "fs2-core" % fs2Version
+    )
+  )
+
+lazy val monixStream = (project in file("monix-stream"))
+  .dependsOn(core % "compile->compile;test->test;provided->provided")
+  .dependsOn(monix % "test->test")
+  .settings(commonSettings: _*)
+  .settings(
+    name := "neotypes-monix-stream",
+    libraryDependencies ++= PROVIDED(
+      "io.monix" %% "monix-eval" % monixVersion,
+      "io.monix" %% "monix-reactive" % monixVersion
     )
   )
 

--- a/core/src/main/scala/neotypes/DeferredQuery.scala
+++ b/core/src/main/scala/neotypes/DeferredQuery.scala
@@ -4,7 +4,7 @@ import neotypes.mappers.{ExecutionMapper, ResultMapper}
 
 import scala.collection.mutable.StringBuilder
 
-private[neotypes] final case class DeferredQuery[T](query: String, params: Map[String, Any] = Map.empty) {
+final case class DeferredQuery[T] private[neotypes] (query: String, params: Map[String, Any] = Map.empty) {
   import DeferredQuery.StreamPartiallyApplied
 
   def list[F[_]](session: Session[F])(implicit rm: ResultMapper[T]): F[List[T]] =
@@ -48,7 +48,7 @@ private[neotypes] object DeferredQuery {
   }
 }
 
-private[neotypes] class DeferredQueryBuilder(private val parts: List[DeferredQueryBuilder.Part]) {
+final class DeferredQueryBuilder private[neotypes] (private val parts: List[DeferredQueryBuilder.Part]) {
   import DeferredQueryBuilder.{PARAMETER_NAME_PREFIX, Param, Part, Query}
 
   def query[T]: DeferredQuery[T] = {

--- a/docs/src/main/tut/docs/alternative_effects.md
+++ b/docs/src/main/tut/docs/alternative_effects.md
@@ -12,6 +12,7 @@ title: "Side effect: Future/IO/Task"
 ```scala
 import neotypes.Async._
 import neotypes.implicits._
+import scala.concurrent.Future
 
 val s = driver.session().asScala[Future]
 
@@ -37,6 +38,7 @@ import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import neotypes.monix.implicits._
 import neotypes.implicits._
+import scala.concurrent.duration._
 
 val s = driver.session().asScala[Task]
 
@@ -44,4 +46,5 @@ val s = driver.session().asScala[Task]
 ```
 
 ## Custom side effect type
-In order to support your implementation of side-effects, you need to implement `neotypes.Async[YourIO]` and add to the implicit scope.
+In order to support your implementation of side-effects,
+you need to implement `neotypes.Async[YourIO]` and add it to the implicit scope.

--- a/docs/src/main/tut/docs/streams.md
+++ b/docs/src/main/tut/docs/streams.md
@@ -6,7 +6,10 @@ title: "Streams"
 # Streams
 
 **neotypes** allows to stream large results by lazily consuming the result and putting elements into a stream.
-Currently, there are two implementations of streaming supported out of the box - [Akka Streams](https://doc.akka.io/docs/akka/current/stream/index.html) & [FS2](https://fs2.io/).
+Currently, there are three implementations of streaming supported out of the box _(one for each effect type)_ -
+[**Akka Streams**](https://doc.akka.io/docs/akka/current/stream/index.html) _(for `scala.concurrent.Future`)_,
+[**FS2**](https://fs2.io/) _(for `cats.effect.Async[F]`)_
+& [**Monix Observables**](https://monix.io/docs/3x/reactive/observable.html) _(for `monix.eval.Task`)_.
 
 ## Usage
 
@@ -41,7 +44,7 @@ import neotypes.implicits._
 val s = driver.session().asScala[IO]
 
 "match (p:Person) return p.name"
-  .query[Int]
+  .query[String]
   .stream[Fs2IoStream](s)
   .evalMap(n => IO(println(n)))
   .compile
@@ -59,14 +62,35 @@ import neotypes.implicits._
 
 type F[_] = ??? // As long as there is an instance of cats.effect.Async[F].
 
-val s = driver.session().asScala[IO]
+val s = driver.session().asScala[F]
 
 "match (p:Person) return p.name"
-  .query[Int]
+  .query[String]
   .stream[Fs2FStream[F]#T](s)
   .evalMap(n => F.delay(println(n)))
   .compile
   .drain
+```
+
+### Monix Observables
+
+```scala
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.globa
+import neotypes.monix.implicits._
+import neotypes.monix.stream.MonixStream
+import neotypes.monix.stream.implicits._
+import neotypes.implicits._
+import scala.concurrent.duration._
+
+val s = driver.session().asScala[Task]
+
+"match (p:Person) return p.name"
+  .query[String]
+  .stream[MonixStream](s)
+  .mapEval(n => Task(println(n)))
+  .completedL
+  .runSyncUnsafe(5 seconds)
 ```
 
 -----
@@ -110,7 +134,7 @@ all elements are consumed. This behavior is provided by `DeferredQuery.stream(Se
 
 If you don't see your stream supported.
 You can add your implementation of `neotypes.Stream.Aux[S[_], F[_]]` typeclass,
-and include it to the implicit scope.
+and add it to the implicit scope.
 
 The type parameters in the signature indicate:
 

--- a/fs2-stream/src/main/scala/neotypes/fs2/implicits.scala
+++ b/fs2-stream/src/main/scala/neotypes/fs2/implicits.scala
@@ -1,7 +1,7 @@
 package neotypes.fs2
 
 object implicits {
-  implicit def fs2Stream[_F[_]](implicit F: cats.effect.Sync[_F]): neotypes.Stream.Aux[Fs2FStream[_F]#T, _F] =
+  implicit def fs2Stream[_F[_]](implicit F: cats.effect.Async[_F]): neotypes.Stream.Aux[Fs2FStream[_F]#T, _F] =
     new neotypes.Stream[Fs2FStream[_F]#T] {
       override type F[T] = _F[T]
 

--- a/monix-stream/src/main/scala/neotypes/monix/stream/implicits.scala
+++ b/monix-stream/src/main/scala/neotypes/monix/stream/implicits.scala
@@ -1,0 +1,23 @@
+package neotypes.monix.stream
+
+import monix.eval.Task
+import monix.reactive.Observable
+
+object implicits {
+  implicit val monixStream: neotypes.Stream.Aux[Observable, Task] =
+    new neotypes.Stream[Observable] {
+      override type F[T] = Task[T]
+
+      override def init[T](value: () => Task[Option[T]]): Observable[T] =
+        Observable
+          .repeatEvalF(Task.suspend(value()))
+          .takeWhile(option => option.isDefined)
+          .collect { case Some(t) => t }
+
+      override def onComplete[T](s: Observable[T])(f: => Task[Unit]): Observable[T] =
+        s.guarantee(f)
+
+      override def fToS[T](f: Task[Observable[T]]): Observable[T] =
+        Observable.fromTask(f).flatten
+    }
+}

--- a/monix-stream/src/main/scala/neotypes/monix/stream/package.scala
+++ b/monix-stream/src/main/scala/neotypes/monix/stream/package.scala
@@ -1,0 +1,5 @@
+package neotypes.monix
+
+package object stream {
+  type MonixStream[T] = monix.reactive.Observable[T]
+}

--- a/monix-stream/src/test/scala/neotypes/monix/stream/MonixStreamSpec.scala
+++ b/monix-stream/src/test/scala/neotypes/monix/stream/MonixStreamSpec.scala
@@ -1,0 +1,27 @@
+package neotypes.monix.stream
+
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import neotypes.BaseIntegrationSpec
+import neotypes.monix.implicits._
+import neotypes.monix.stream.implicits._
+import neotypes.implicits._
+import org.scalatest.AsyncFlatSpec
+
+class MonixStreamSpec extends AsyncFlatSpec with BaseIntegrationSpec {
+  it should "work with monix.reactive.Observable" in {
+    val s = driver.session().asScala[Task]
+
+    "match (p:Person) return p.name"
+      .query[Int]
+      .stream[MonixStream](s)
+      .toListL
+      .runToFuture
+      .map {
+        names => assert(names == (0 to 10).toList)
+      }
+  }
+
+  override val initQuery: String =
+    (0 to 10).map(n => s"CREATE (:Person {name: $n})").mkString("\n")
+}


### PR DESCRIPTION
Implements the Stream typeclass for `monix.reactive.Observable`.

Disclaimer, this is my very first time using **Monix**. I basically just read the docs and searched for methods on the scaladoc that _"type-check"_.
As such, this may be a very naive implementation.

_(While the same could be said about my implementation for **FS2**, that was not my first time with it, also I use that on my daily projects)_.