### PR TITLE
ResultMapper/ValueMapper derivation functions

### DIFF
--- a/core/src/main/scala/neotypes/mappers.scala
+++ b/core/src/main/scala/neotypes/mappers.scala
@@ -7,25 +7,170 @@ import scala.annotation.implicitNotFound
 import scala.reflect.ClassTag
 
 object mappers {
-  @implicitNotFound("Could not find the ResultMapper for ${T}")
-  trait ResultMapper[T] {
-    def to(value: Seq[(String, Value)], typeHint: Option[TypeHint]): Either[Throwable, T]
+  @implicitNotFound("Could not find the ResultMapper for ${A}")
+  trait ResultMapper[A] { self =>
+    def to(value: Seq[(String, Value)], typeHint: Option[TypeHint]): Either[Throwable, A]
+
+    /**
+      * Allows supplying a secondary [[ResultMapper]] to try if the original fails.
+      *
+      * @param mapper A [[ResultMapper]] to use if the current one fails.
+      * @tparam AA A type that is possibly a supertype of your original [[ResultMapper]] type.
+      * @return A new [[ResultMapper]] that returns the type of the supplied secondary mapper.
+      */
+    def or[AA >: A](mapper: => ResultMapper[AA]): ResultMapper[AA] = new ResultMapper[AA] {
+      override def to(value: Seq[(String, Value)], typeHint: Option[TypeHint]): Either[Throwable, AA] = {
+        self.to(value, typeHint) match {
+          case r @ Right(_) => r
+          case Left(_) => mapper.to(value, typeHint)
+        }
+      }
+    }
+
+    /**
+      * Creates a new [[ResultMapper]] by applying a function to the result value, if successful.
+      *
+      * @param f A function to apply to the result value of this ResultMapper.
+      * @tparam B The return type of your supplied function.
+      * @return A new ResultMapper that applies your function to the result.
+      */
+    def map[B](f: A => B): ResultMapper[B] = new ResultMapper[B] {
+      override def to(value: Seq[(String, Value)], typeHint: Option[TypeHint]): Either[Throwable, B] =
+        self.to(value, typeHint).right.map(f)
+    }
+
+    /**
+      * Bind a function over this [[ResultMapper]], if successful.
+      * Useful for creating decoders that depend on multiple values in sequence.
+      *
+      * @param f A function that returns a new [[ResultMapper]].
+      * @tparam B The result type of your new [[ResultMapper]] from your function.
+      * @return A new [[ResultMapper]] derived from the value your original [[ResultMapper]] outputs.
+      */
+    def flatMap[B](f: A => ResultMapper[B]): ResultMapper[B] = new ResultMapper[B] {
+      override def to(value: Seq[(String, Value)], typeHint: Option[TypeHint]): Either[Throwable, B] = self.to(value, typeHint) match {
+        case Right(a) => f(a).to(value, typeHint)
+        case l @ Left(_) => l.asInstanceOf[Either[Throwable, B]]
+      }
+    }
+
+    /**
+      * Combines the results of this [[ResultMapper]] with another as a tuple pair.
+      *
+      * @param fa A second [[ResultMapper]] that reads the same input values.
+      * @tparam B The type of your second [[ResultMapper]] results.
+      * @return A [[ResultMapper]] that produces a pair of values.
+      */
+    def product[B](fa: ResultMapper[B]): ResultMapper[(A, B)] = new ResultMapper[(A, B)] {
+      override def to(value: Seq[(String, Value)], typeHint: Option[TypeHint]): Either[Throwable, (A, B)] =
+        self.flatMap(t => fa.map(a => (t, a))).to(value, typeHint)
+    }
+
+    /**
+      * Produces a [[ResultMapper]] where either the original or secondary mapper succeeds.
+      * The original mapper result is on the Left side, and the secondary mapper is on the Right.
+      *
+      * @param fa A secondary [[ResultMapper]] to try if the first one fails.
+      * @tparam B The result type of your secondary [[ResultMapper]].
+      * @return A [[ResultMapper]] that, if sucessful, will return a value of either the original or secondary type.
+      */
+    def either[B](fa: ResultMapper[B]): ResultMapper[Either[A, B]] = new ResultMapper[Either[A, B]] {
+      override def to(value: Seq[(String, Value)], typeHint: Option[TypeHint]): Either[Throwable, Either[A, B]] =
+        self.to(value, typeHint) match {
+          case Right(r) => Right(Left(r))
+          case Left(_) => fa.to(value, typeHint) match {
+            case Right(r) => Right(Right(r))
+            case l @ Left(_) => l.asInstanceOf[Either[Throwable, Either[A, B]]]
+          }
+        }
+    }
   }
 
-  @implicitNotFound("Could not find the ValueMapper for ${T}")
-  trait ValueMapper[T] {
-    def to(fieldName: String, value: Option[Value]): Either[Throwable, T]
+  @implicitNotFound("Could not find the ValueMapper for ${A}")
+  trait ValueMapper[A] { self =>
+    def to(fieldName: String, value: Option[Value]): Either[Throwable, A]
+
+    /**
+      * Allows supplying a secondary [[ValueMapper]] to try if the original fails.
+      *
+      * @param mapper A [[ValueMapper]] to use if the current one fails.
+      * @tparam AA A type that is possibly a supertype of your original [[ValueMapper]] type.
+      * @return A new [[ValueMapper]] that returns the type of the supplied secondary mapper.
+      */
+    def or[AA >: A](mapper: => ValueMapper[AA]): ValueMapper[AA] = new ValueMapper[AA] {
+      override def to(fieldName: String, value: Option[Value]): Either[Throwable, AA] = self.to(fieldName, value) match {
+        case r @ Right(_) => r
+        case Left(_) => mapper.to(fieldName, value)
+      }
+    }
+
+    /**
+      * Creates a new [[ValueMapper]] by applying a function to the result value, if successful.
+      *
+      * @param f A function to apply to the result value of this ResultMapper.
+      * @tparam B The return type of your supplied function.
+      * @return A new ResultMapper that applies your function to the result.
+      */
+    def map[B](f: A => B): ValueMapper[B] = new ValueMapper[B] {
+      override def to(fieldName: String, value: Option[Value]): Either[Throwable, B] = self.to(fieldName, value).right.map(f)
+    }
+
+    /**
+      * Bind a function over this [[ValueMapper]], if successful.
+      * Useful for creating decoders that depend on multiple values in sequence.
+      *
+      * @param f A function that returns a new [[ValueMapper]].
+      * @tparam B The result type of your new [[ValueMapper]] from your function.
+      * @return A new [[ValueMapper]] derived from the value your original [[ValueMapper]] outputs.
+      */
+    def flatMap[B](f: A => ValueMapper[B]): ValueMapper[B] = new ValueMapper[B] {
+      override def to(fieldName: String, value: Option[Value]): Either[Throwable, B] = self.to(fieldName, value) match {
+        case Right(a) => f(a).to(fieldName, value)
+        case l @ Left(_) => l.asInstanceOf[Either[Throwable, B]]
+      }
+    }
+
+    /**
+      * Combines the results of this [[ValueMapper]] with another as a tuple pair.
+      *
+      * @param fa A second [[ValueMapper]] that reads the same input values.
+      * @tparam B The type of your second [[ValueMapper]] results.
+      * @return A [[ValueMapper]] that produces a pair of values.
+      */
+    def product[B](fa: ValueMapper[B]): ValueMapper[(A, B)] = new ValueMapper[(A, B)] {
+      override def to(fieldName: String, value: Option[Value]): Either[Throwable, (A, B)] =
+        self.flatMap(t => fa.map(a => (t, a))).to(fieldName, value)
+    }
+
+    /**
+      * Produces a [[ValueMapper]] where either the original or secondary mapper succeeds.
+      * The original mapper result is on the Left side, and the secondary mapper is on the Right.
+      *
+      * @param fa A secondary [[ValueMapper]] to try if the first one fails.
+      * @tparam B The result type of your secondary [[ValueMapper]].
+      * @return A [[ValueMapper]] that, if sucessful, will return a value of either the original or secondary type.
+      */
+    def either[B](fa: ValueMapper[B]): ValueMapper[Either[A, B]] = new ValueMapper[Either[A, B]] {
+      override def to(fieldName: String, value: Option[Value]): Either[Throwable, Either[A, B]] =
+        self.to(fieldName, value) match {
+          case Right(r) => Right(Left(r))
+          case Left(_) => fa.to(fieldName, value) match {
+            case Right(r) => Right(Right(r))
+            case l @ Left(_) => l.asInstanceOf[Either[Throwable, Either[A, B]]]
+          }
+        }
+    }
   }
 
-  @implicitNotFound("Could not find the ExecutionMapper for ${T}")
-  trait ExecutionMapper[T] {
-    def to(resultSummary: ResultSummary): Either[Throwable, T]
+  @implicitNotFound("Could not find the ExecutionMapper for ${A}")
+  trait ExecutionMapper[A] {
+    def to(resultSummary: ResultSummary): Either[Throwable, A]
   }
 
   final case class TypeHint(isTuple: Boolean)
 
   object TypeHint {
-    def apply[T](classTag: ClassTag[T]): TypeHint =
+    def apply[A](classTag: ClassTag[A]): TypeHint =
       new TypeHint(classTag.runtimeClass.getName.startsWith("scala.Tuple"))
   }
 }

--- a/core/src/test/scala/neotypes/MapperSpec.scala
+++ b/core/src/test/scala/neotypes/MapperSpec.scala
@@ -1,0 +1,99 @@
+package neotypes
+
+import neotypes.implicits.{IntResultMapper, IntValueMapper, StringResultMapper, StringValueMapper}
+import neotypes.mappers.{ResultMapper, TypeHint, ValueMapper}
+import org.neo4j.driver.internal.value.{IntegerValue, StringValue}
+import org.neo4j.driver.v1.Value
+import org.scalatest.FreeSpec
+
+class MapperSpec extends FreeSpec {
+
+  case class MyCaseClass(value: String)
+
+  "ResultMapper" - {
+    "should allow defining a secondary mapper" in {
+      val failingMapper = new ResultMapper[String] {
+        override def to(value: Seq[(String, Value)], typeHint: Option[TypeHint]): Either[Throwable, String] =
+          Left(new Exception)
+      }
+      val result = failingMapper.or(StringResultMapper).to(Seq(("value", new StringValue("string"))), None)
+      assert(result == Right("string"))
+    }
+
+    "should be mappable" in {
+      val caseClassMapper = StringResultMapper.map(x => MyCaseClass(x + "2"))
+      val result = caseClassMapper.to(Seq(("value", new StringValue("1"))), None)
+      assert(result == Right(MyCaseClass("12")))
+    }
+
+    "should be flatmappable" in {
+      val flatMappedMapper = StringResultMapper.flatMap { str =>
+        new ResultMapper[Int] {
+          override def to(value: Seq[(String, Value)], typeHint: Option[TypeHint]): Either[Throwable, Int] =
+            Right(str.length)
+        }
+      }
+      val result = flatMappedMapper.to(Seq(("value", new StringValue("twelve chars"))), None)
+      assert(result == Right(12))
+    }
+
+    "should derive a product mapper" in {
+      val lengthOfStringMapper = StringResultMapper.map(_.length)
+      val productMapper = StringResultMapper.product(lengthOfStringMapper)
+      val result = productMapper.to(Seq(("value", new StringValue("twelve chars"))), None)
+      assert(result == Right("twelve chars", 12))
+    }
+
+    "should derive an either mapper" in {
+      val eitherIntOrStringMapper = IntResultMapper.either(StringResultMapper)
+      val resultInt = eitherIntOrStringMapper.to(Seq(("value", new IntegerValue(1))), None)
+      val resultString = eitherIntOrStringMapper.to(Seq(("value", new StringValue("string"))), None)
+      assert(resultInt == Right(Left(1)))
+      assert(resultString == Right(Right("string")))
+    }
+  }
+
+  "ValueMapper" - {
+    "should allow defining a secondary mapper" in {
+      val failingMapper = new ValueMapper[String] {
+        override def to(fieldName: String, value: Option[Value]): Either[Throwable, String] =
+          Left(new Exception)
+      }
+      val result = failingMapper.or(StringValueMapper).to("value", Some(new StringValue("string")))
+      assert(result == Right("string"))
+    }
+
+    "should be mappable" in {
+      val caseClassMapper = StringValueMapper.map(x => MyCaseClass(x + "2"))
+      val result = caseClassMapper.to("value", Some(new StringValue("1")))
+      assert(result == Right(MyCaseClass("12")))
+    }
+
+    "should be flatmappable" in {
+      val flatMappedMapper = StringValueMapper.flatMap { str =>
+        new ValueMapper[Int] {
+          override def to(fieldName: String, value: Option[Value]): Either[Throwable, Int] =
+            Right(str.length)
+        }
+      }
+      val result = flatMappedMapper.to("value", Some(new StringValue("twelve chars")))
+      assert(result == Right(12))
+    }
+
+    "should be able to derive a product mapper" in {
+      val lengthOfStringMapper = StringValueMapper.map(_.length)
+      val productMapper = StringValueMapper.product(lengthOfStringMapper)
+      val result = productMapper.to("value", Some(new StringValue("twelve chars")))
+      assert(result == Right("twelve chars", 12))
+    }
+
+    "should derive an either mapper" in {
+      val eitherIntOrStringMapper = IntValueMapper.either(StringValueMapper)
+      val resultInt = eitherIntOrStringMapper.to("value", Some(new IntegerValue(1)))
+      val resultString = eitherIntOrStringMapper.to("value", Some(new StringValue("string")))
+      assert(resultInt == Right(Left(1)))
+      assert(resultString == Right(Right("string")))
+    }
+  }
+
+}

--- a/core/src/test/scala/neotypes/MapperSpec.scala
+++ b/core/src/test/scala/neotypes/MapperSpec.scala
@@ -11,6 +11,29 @@ class MapperSpec extends FreeSpec {
   case class MyCaseClass(value: String)
 
   "ResultMapper" - {
+    "constructors" - {
+      "should summon implicit ResultMapper instances" in {
+        val strMapper = ResultMapper[String]
+        assert(strMapper == StringResultMapper)
+      }
+      "should create an instance based on a function" in {
+        def myParsingFunction(vals: Seq[(String, Value)], typeHint: Option[TypeHint]) = Right("function works")
+        val myInstanceMapper = ResultMapper.instance(myParsingFunction)
+        val result = myInstanceMapper.to(Seq(("value", new StringValue("function doesn't work"))), None)
+        assert(result == Right("function works"))
+      }
+      "should return a constant result value" in {
+        val constMapper = ResultMapper.const[String]("const")
+        val result = constMapper.to(Seq(("value", new StringValue("not const"))), None)
+        assert(result == Right("const"))
+      }
+      "should return a constant failure" in {
+        val myException = new Exception("Example Exception")
+        val failureMapper = ResultMapper.failed[String](myException)
+        val result = failureMapper.to(Seq(("value", new StringValue("value"))), None)
+        assert(result == Left(myException))
+      }
+    }
     "should allow defining a secondary mapper" in {
       val failingMapper = new ResultMapper[String] {
         override def to(value: Seq[(String, Value)], typeHint: Option[TypeHint]): Either[Throwable, String] =
@@ -54,6 +77,29 @@ class MapperSpec extends FreeSpec {
   }
 
   "ValueMapper" - {
+    "constructors" - {
+      "should summon implicit ValueMapper instances" in {
+        val strMapper = ValueMapper[String]
+        assert(strMapper == StringValueMapper)
+      }
+      "should create an instance based on a function" in {
+        def myParsingFunction(name: String, value: Option[Value]) = Right("function works")
+        val myInstanceMapper = ValueMapper.instance(myParsingFunction)
+        val result = myInstanceMapper.to("value", Some(new StringValue("function doesn't work")))
+        assert(result == Right("function works"))
+      }
+      "should return a constant result value" in {
+        val constMapper = ValueMapper.const[String]("const")
+        val result = constMapper.to("value", Some(new StringValue("not const")))
+        assert(result == Right("const"))
+      }
+      "should return a constant failure" in {
+        val myException = new Exception("Example Exception")
+        val failureMapper = ValueMapper.failed[String](myException)
+        val result = failureMapper.to("value", Some(new StringValue("value")))
+        assert(result == Left(myException))
+      }
+    }
     "should allow defining a secondary mapper" in {
       val failingMapper = new ValueMapper[String] {
         override def to(fieldName: String, value: Option[Value]): Either[Throwable, String] =


### PR DESCRIPTION
Hello, just wanted to say first, thanks for the awesome project!

I was hoping to add some code that would make it a little easier to derive ResultMappers and ValueMappers from existing mappers. I took some inspiration from other libraries that have their own "Encoder/Decoder" style (mainly Circe and PureConfig) and wrote a few handy methods that should allow creating custom mappers easily.

It's not a full solution with (i.e.) Cats support, but if there's interest I would be happy to write an extra optional module for neotypes that adds some Cats instances where appropriate based on this. I hope it looks good to you, and let me know if there's anything I can tweak!

Summary of the changes:
* Added `or, map, flatMap, product, either` functions to both ResultMapper and ValueMapper.
* Changed type parameter from `T` to `A` (made some conventions a little more straightforward, particularly for Map since `T => A` looks a little weird compared to `A => B`)
* Added some basic tests for each of the new methods

If you'd like me to flesh out the tests a bit I can build on them with ScalaCheck, but I didn't want to be too disruptive with these changes.