### PR TITLE
Vector support, Map query result & cats.data instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ For early adopters:
 |`"com.dimafeng" %% "neotypes-monix-stream" % version`|result streaming for Monix Observables.|
 |`"com.dimafeng" %% "neotypes-zio-stream" % version`|result streaming for ZIO ZStreams.|
 |`"com.dimafeng" %% "neotypes-refined" % version`|support to insert and retrieve refined values.|
+|`"com.dimafeng" %% "neotypes-cats-data" % version`|support to insert and retrieve `cats.data` values.|
 
 **Scala lightweight, type-safe, asynchronous driver (not opinionated on side-effect implementation) for neo4j**.
 

--- a/akka-stream/src/test/scala/neotypes/akkastreams/AkkaStreamSpec.scala
+++ b/akka-stream/src/test/scala/neotypes/akkastreams/AkkaStreamSpec.scala
@@ -8,11 +8,10 @@ import neotypes.akkastreams.implicits._
 import neotypes.implicits.mappers.results._
 import neotypes.implicits.syntax.session._
 import neotypes.implicits.syntax.string._
-import org.scalatest.AsyncFlatSpec
 
 import scala.concurrent.Future
 
-class AkkaStreamSpec extends AsyncFlatSpec with BaseIntegrationSpec {
+class AkkaStreamSpec extends BaseIntegrationSpec {
   it should "work with Akka streams" in {
     val s = driver.session().asScala[Future]
     implicit val system = ActorSystem("QuickStart")
@@ -27,6 +26,5 @@ class AkkaStreamSpec extends AsyncFlatSpec with BaseIntegrationSpec {
       }
   }
 
-  override val initQuery: String =
-    (0 to 10).map(n => s"CREATE (:Person {name: $n})").mkString("\n") //+ "\n CREATE (:Person {name: 'asd'})"
+  override val initQuery: String = BaseIntegrationSpec.MULTIPLE_VALUES_INIT_QUERY
 }

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ val testcontainersScalaVersion = "0.23.0"
 val mockitoVersion = "1.10.19"
 val scalaTestVersion = "3.0.5"
 val slf4jVersion = "1.7.21"
+val catsVersion = "1.6.1"
 val catsEffectsVersion = "1.2.0"
 val monixVersion = "3.0.0-RC2"
 val akkaStreamVersion = "2.5.19"
@@ -58,7 +59,8 @@ lazy val root = (project in file("."))
     fs2Stream,
     monixStream,
     zioStream,
-    refined
+    refined,
+    catsData
   )
   .settings(noPublishSettings)
   .settings(
@@ -184,6 +186,16 @@ lazy val refined = (project in file("refined"))
     name := "neotypes-refined",
     libraryDependencies ++= PROVIDED(
       "eu.timepit" %% "refined" % refinedVersion
+    )
+  )
+
+lazy val catsData = (project in file("cats-data"))
+  .dependsOn(core % "compile->compile;test->test;provided->provided")
+  .settings(commonSettings: _*)
+  .settings(
+    name := "neotypes-cats-data",
+    libraryDependencies ++= PROVIDED(
+      "org.typelevel" %% "cats-core" % catsVersion
     )
   )
 

--- a/cats-data/src/test/scala/neotypes/cats/data/CatsDataSpec.scala
+++ b/cats-data/src/test/scala/neotypes/cats/data/CatsDataSpec.scala
@@ -1,0 +1,209 @@
+package neotypes.cats.data
+
+import neotypes.CleaningIntegrationSpec
+import neotypes.cats.data.implicits._
+import neotypes.exceptions.UncoercibleException
+import neotypes.implicits.mappers.all._
+import neotypes.implicits.syntax.cypher._
+import neotypes.implicits.syntax.string._
+import neotypes.implicits.syntax.session._
+
+import cats.data.{
+  Chain,
+  Const,
+  NonEmptyChain,
+  NonEmptyList,
+  NonEmptyMap,
+  NonEmptySet,
+  NonEmptyVector
+}
+import _root_.cats.instances.string._ // Brings the implicit Order[String] instance into the scope.
+import _root_.cats.instances.int._ // Brings the implicit Order[Int] instance into the scope.
+
+import scala.concurrent.Future
+
+class CatsDataSpec extends CleaningIntegrationSpec {
+  import CatsDataSpec._
+
+  it should "work with Chain" in {
+    val s = driver.session().asScala[Future]
+
+    val messages: Messages = Chain("a", "b")
+
+    for {
+      _ <- c"CREATE (chat: Chat { user1: ${"Balmung"}, user2: ${"Luis"}, messages: ${messages} })".query[Unit].execute(s)
+      r1 <- "MATCH (chat: Chat) RETURN chat.messages".query[Messages].single(s)
+      r2 <- "MATCH (chat: Chat) RETURN chat".query[Chat].single(s)
+    } yield {
+      assert(r1 == messages)
+      assert(r2 == Chat("Balmung", "Luis", messages))
+    }
+  }
+
+  it should "work with Const" in {
+    val s = driver.session().asScala[Future]
+
+    val name: Name = Const("Balmung")
+
+    for {
+      _ <- c"CREATE (user: User { name: ${name} })".query[Unit].execute(s)
+      r1 <- "MATCH (user: User) RETURN user.name".query[Name].single(s)
+      r2 <- "MATCH (user: User) RETURN user".query[User].single(s)
+    } yield {
+      assert(r1 == name)
+      assert(r2 == User(name))
+    }
+  }
+
+  it should "work with NonEmptyChain" in {
+    val s = driver.session().asScala[Future]
+
+    val errors: Errors = NonEmptyChain("a", "b")
+
+    for {
+      _ <- c"CREATE (stackTrace: StackTrace { line: 1, errors: ${errors} })".query[Unit].execute(s)
+      r1 <- "MATCH (stackTrace: StackTrace) RETURN stackTrace.errors".query[Errors].single(s)
+      r2 <- "MATCH (stackTrace: StackTrace) RETURN stackTrace".query[StackTrace].single(s)
+    } yield {
+      assert(r1 == errors)
+      assert(r2 == StackTrace(1, errors))
+    }
+  }
+
+  it should "fail if retrieving an empty list as a NonEmptyChain" in {
+    val s = driver.session().asScala[Future]
+
+    recoverToSucceededIf[UncoercibleException] {
+      for {
+        _ <- "CREATE (stackTrace: StackTrace { line: 1, errors: [] })".query[Unit].execute(s)
+        stackTrace <- "MATCH (stackTrace: StackTrace) RETURN stackTrace".query[StackTrace].single(s)
+      } yield stackTrace
+    }
+  }
+
+  it should "work with NonEmptyList" in {
+    val s = driver.session().asScala[Future]
+
+    val items: Items = NonEmptyList.of("a", "b")
+
+    for {
+      _ <- c"CREATE (player: Player { name: ${"Luis"}, items: ${items} })".query[Unit].execute(s)
+      r1 <- "MATCH (player: Player) RETURN player.items".query[Items].single(s)
+      r2 <- "MATCH (player: Player) RETURN player".query[Player].single(s)
+    } yield {
+      assert(r1 == items)
+      assert(r2 == Player("Luis", items))
+    }
+  }
+
+  it should "fail if retrieving an empty list as a NonEmptyList" in {
+    val s = driver.session().asScala[Future]
+
+    recoverToSucceededIf[UncoercibleException] {
+      for {
+        _ <- "CREATE (player: Player { name: \"Luis\", items: [] })".query[Unit].execute(s)
+        player <- "MATCH (player: Player) RETURN player".query[Player].single(s)
+      } yield player
+    }
+  }
+
+  it should "work with NonEmptyMap" in {
+    val s = driver.session().asScala[Future]
+
+    val properties: Properties = NonEmptyMap.of("a" -> true, "b" -> false)
+
+    for {
+      _ <- c"CREATE (config: Config ${properties})".query[Unit].execute(s)
+      r1 <- "MATCH (config: Config) RETURN config { .* }".query[Properties].single(s)
+      r2 <- "MATCH (config: Config) RETURN \"dev\" AS env, config { .* } AS properties".query[Config].single(s)
+    } yield {
+      assert(r1 == properties)
+      assert(r2 == Config("dev", properties))
+    }
+  }
+
+  it should "fail if retrieving an empty map a NonEmptyMap" in {
+    val s = driver.session().asScala[Future]
+
+    recoverToSucceededIf[UncoercibleException] {
+      for {
+        properties <- "RETURN {}".query[Properties].single(s)
+      } yield properties
+    }
+  }
+
+  it should "work with NonEmptySet" in {
+    val s = driver.session().asScala[Future]
+
+    val numbers: Numbers = NonEmptySet.of(1, 3, 5)
+
+    for {
+      _ <- c"CREATE (set: Set { name: ${"favourites"}, numbers: ${numbers} })".query[Unit].execute(s)
+      r1 <- "MATCH (set: Set) RETURN set.numbers".query[Numbers].single(s)
+      r2 <- "MATCH (set: Set) RETURN set".query[MySet].single(s)
+    } yield {
+      assert(r1 == numbers)
+      assert(r2 == MySet("favourites", numbers))
+    }
+  }
+
+  it should "fail if retrieving an empty list as a NonEmptySet" in {
+    val s = driver.session().asScala[Future]
+
+    recoverToSucceededIf[UncoercibleException] {
+      for {
+        _ <- "CREATE (set: Set { name: \"favourites\", numbers: [] })".query[Unit].execute(s)
+        set <- "MATCH (set: Set) RETURN set".query[MySet].single(s)
+      } yield set
+    }
+  }
+
+  it should "work with NonEmptyVector" in {
+    val s = driver.session().asScala[Future]
+
+    val groceries: Groceries = NonEmptyVector.of("a", "b")
+
+    for {
+      _ <- c"CREATE (purchase: Purchase { total: 12.5, groceries: ${groceries} })".query[Unit].execute(s)
+      r1 <- "MATCH (purchase: Purchase) RETURN purchase.groceries".query[Groceries].single(s)
+      r2 <- "MATCH (purchase: Purchase) RETURN purchase".query[Purchase].single(s)
+    } yield {
+      assert(r1 == groceries)
+      assert(r2 == Purchase(12.5d, groceries))
+    }
+  }
+
+  it should "fail if retrieving an empty list as a NonEmptyVector" in {
+    val s = driver.session().asScala[Future]
+
+    recoverToSucceededIf[UncoercibleException] {
+      for {
+        _ <- "CREATE (purchase: Purchase { total: 12.5, groceries: [] })".query[Unit].execute(s)
+        purchase <- "MATCH (purchase: Purchase) RETURN purchase".query[Purchase].single(s)
+      } yield purchase
+    }
+  }
+}
+
+object CatsDataSpec {
+  type Messages = Chain[String]
+  final case class Chat(user1: String, user2: String, messages: Messages)
+
+  type Name = Const[String, Int]
+  final case class User(name: Name)
+
+  type Errors = NonEmptyChain[String]
+  final case class StackTrace(line: Int, errors: Errors)
+
+  type Items = NonEmptyList[String]
+  final case class Player(name: String, items: Items)
+
+  type Properties = NonEmptyMap[String, Boolean]
+  final case class Config(env: String, properties: Properties)
+
+  type Numbers = NonEmptySet[Int]
+  final case class MySet(name: String, numbers: Numbers)
+
+  type Groceries = NonEmptyVector[String]
+  final case class Purchase(total: Double, groceries: Groceries)
+}

--- a/cats-effect/src/main/scala/neotypes/cats/effect/implicits.scala
+++ b/cats-effect/src/main/scala/neotypes/cats/effect/implicits.scala
@@ -1,4 +1,4 @@
-package neotypes.cats
+package neotypes.cats.effect
 
 object implicits {
   implicit def catsAsync[F[_]](implicit F: cats.effect.Async[F]): neotypes.Async[F] =

--- a/cats-effect/src/test/scala/neotypes/cats/CatsAsyncSpec.scala
+++ b/cats-effect/src/test/scala/neotypes/cats/CatsAsyncSpec.scala
@@ -7,9 +7,8 @@ import neotypes.implicits.syntax.session._
 import neotypes.implicits.syntax.string._
 import neotypes.BaseIntegrationSpec
 import org.neo4j.driver.v1.exceptions.ClientException
-import org.scalatest.AsyncFlatSpec
 
-class CatsAsyncSpec extends AsyncFlatSpec with BaseIntegrationSpec {
+class CatsAsyncSpec extends BaseIntegrationSpec {
   it should "work with IO" in {
     val s = driver.session().asScala[IO]
 

--- a/cats-effect/src/test/scala/neotypes/cats/effect/CatsAsyncSpec.scala
+++ b/cats-effect/src/test/scala/neotypes/cats/effect/CatsAsyncSpec.scala
@@ -1,7 +1,7 @@
-package neotypes.cats
+package neotypes.cats.effect
 
 import cats.effect.IO
-import neotypes.cats.implicits._
+import neotypes.cats.effect.implicits._
 import neotypes.implicits.mappers.results._
 import neotypes.implicits.syntax.session._
 import neotypes.implicits.syntax.string._

--- a/core/src/main/scala/neotypes/DeferredQuery.scala
+++ b/core/src/main/scala/neotypes/DeferredQuery.scala
@@ -12,6 +12,12 @@ final case class DeferredQuery[T] private[neotypes] (query: String, params: Map[
   def list[F[_]](session: Session[F])(implicit rm: ResultMapper[T]): F[List[T]] =
     session.transact(tx => list(tx))
 
+  def set[F[_]](session: Session[F])(implicit rm: ResultMapper[T]): F[Set[T]] =
+    session.transact(tx => set(tx))
+
+  def vector[F[_]](session: Session[F])(implicit rm: ResultMapper[T]): F[Vector[T]] =
+    session.transact(tx => vector(tx))
+
   def single[F[_]](session: Session[F])(implicit rm: ResultMapper[T]): F[T] =
     session.transact(tx => single(tx))
 
@@ -20,6 +26,12 @@ final case class DeferredQuery[T] private[neotypes] (query: String, params: Map[
 
   def list[F[_]](tx: Transaction[F])(implicit rm: ResultMapper[T]): F[List[T]] =
     tx.list(query, params)
+
+  def set[F[_]](tx: Transaction[F])(implicit rm: ResultMapper[T]): F[Set[T]] =
+    tx.set(query, params)
+
+  def vector[F[_]](tx: Transaction[F])(implicit rm: ResultMapper[T]): F[Vector[T]] =
+    tx.vector(query, params)
 
   def single[F[_]](tx: Transaction[F])(implicit rm: ResultMapper[T]): F[T] =
     tx.single(query, params)

--- a/core/src/main/scala/neotypes/implicits/mappers/ParameterMappers.scala
+++ b/core/src/main/scala/neotypes/implicits/mappers/ParameterMappers.scala
@@ -69,23 +69,28 @@ private[implicits] trait ParameterMappers {
   implicit final val ZonedDateTimeParameterMapper: ParameterMapper[ZonedDateTime] =
     ParameterMapper.identity
 
-  implicit def ListParameterMapper[T](implicit mapper: ParameterMapper[T]): ParameterMapper[List[T]] =
+  implicit def listParameterMapper[T](implicit mapper: ParameterMapper[T]): ParameterMapper[List[T]] =
     ParameterMapper.fromCast { list =>
       list.map(v => mapper.toQueryParam(v).underlying).asJava
     }
 
-  implicit def MapParameterMapper[T](implicit mapper: ParameterMapper[T]): ParameterMapper[Map[String, T]] =
+  implicit def mapParameterMapper[T](implicit mapper: ParameterMapper[T]): ParameterMapper[Map[String, T]] =
     ParameterMapper.fromCast { map =>
       map.mapValues(v => mapper.toQueryParam(v).underlying).asJava
     }
 
-  implicit def OptionParameterMapper[T >: Null](implicit mapper: ParameterMapper[T]): ParameterMapper[Option[T]] =
+  implicit def optionParameterMapper[T >: Null](implicit mapper: ParameterMapper[T]): ParameterMapper[Option[T]] =
     ParameterMapper.fromCast { optional =>
       optional.map(v => mapper.toQueryParam(v).underlying).orNull
     }
 
-  implicit def SetParameterMapper[T](implicit mapper: ParameterMapper[T]): ParameterMapper[Set[T]] =
+  implicit def setParameterMapper[T](implicit mapper: ParameterMapper[T]): ParameterMapper[Set[T]] =
     ParameterMapper.fromCast { set =>
       set.map(v => mapper.toQueryParam(v).underlying).asJava
+    }
+
+  implicit def vectorParameterMapper[T](implicit mapper: ParameterMapper[T]): ParameterMapper[Vector[T]] =
+    ParameterMapper.fromCast { vector =>
+      vector.map(v => mapper.toQueryParam(v).underlying).asJava
     }
 }

--- a/core/src/main/scala/neotypes/implicits/mappers/ResultMappers.scala
+++ b/core/src/main/scala/neotypes/implicits/mappers/ResultMappers.scala
@@ -168,4 +168,7 @@ private[neotypes] trait ResultMappers extends ValueMappers {
 
   implicit def setResultMapper[T: ValueMapper]: ResultMapper[Set[T]] =
     ResultMapper.fromValueMapper
+
+  implicit def vectorResultMapper[T: ValueMapper]: ResultMapper[Vector[T]] =
+    ResultMapper.fromValueMapper
 }

--- a/core/src/main/scala/neotypes/implicits/mappers/ValueMappers.scala
+++ b/core/src/main/scala/neotypes/implicits/mappers/ValueMappers.scala
@@ -152,7 +152,9 @@ private[implicits] trait ValueMappers {
 
           case Some(value) =>
             traverseAsMap(value.keys.asScala.iterator) { key: String =>
-              key -> mapper.to(key, Option(value.get(key)))
+              mapper.to(key, Option(value.get(key))).right.map { value =>
+                key -> value
+              }
             }
         }
     }

--- a/core/src/main/scala/neotypes/implicits/mappers/ValueMappers.scala
+++ b/core/src/main/scala/neotypes/implicits/mappers/ValueMappers.scala
@@ -6,7 +6,7 @@ import java.util.UUID
 
 import exceptions.{ConversionException, PropertyNotFoundException}
 import mappers.{ResultMapper, TypeHint, ValueMapper}
-import utils.traverse.{traverseAsList, traverseAsMap, traverseAsSet}
+import utils.traverse.{traverseAsList, traverseAsMap, traverseAsSet, traverseAsVector}
 import types.Path
 
 import org.neo4j.driver.internal.types.InternalTypeSystem
@@ -210,6 +210,20 @@ private[implicits] trait ValueMappers {
 
           case Some(value) =>
             traverseAsSet(value.values.asScala.iterator) { value: Value =>
+              mapper.to("", Option(value))
+            }
+        }
+    }
+
+  implicit def vectorValueMapper[T](implicit mapper: ValueMapper[T]): ValueMapper[Vector[T]] =
+    new ValueMapper[Vector[T]] {
+      override def to(fieldName: String, value: Option[Value]): Either[Throwable, Vector[T]] =
+        value match {
+          case None =>
+            Right(Vector.empty)
+
+          case Some(value) =>
+            traverseAsVector(value.values.asScala.iterator) { value: Value =>
               mapper.to("", Option(value))
             }
         }

--- a/core/src/main/scala/neotypes/mappers.scala
+++ b/core/src/main/scala/neotypes/mappers.scala
@@ -53,10 +53,7 @@ object mappers {
       */
     def flatMap[B](f: A => ResultMapper[B]): ResultMapper[B] = new ResultMapper[B] {
       override def to(value: Seq[(String, Value)], typeHint: Option[TypeHint]): Either[Throwable, B] =
-        self.to(value, typeHint) match {
-          case Right(a) => f(a).to(value, typeHint)
-          case Left(e) => Left(e)
-        }
+        self.to(value, typeHint).right.flatMap(a => f(a).to(value, typeHint))
     }
 
     /**
@@ -192,10 +189,8 @@ object mappers {
       * @return A new [[ValueMapper]] derived from the value your original [[ValueMapper]] outputs.
       */
     def flatMap[B](f: A => ValueMapper[B]): ValueMapper[B] = new ValueMapper[B] {
-      override def to(fieldName: String, value: Option[Value]): Either[Throwable, B] = self.to(fieldName, value) match {
-        case Right(a) => f(a).to(fieldName, value)
-        case Left(e) => Left(e)
-      }
+      override def to(fieldName: String, value: Option[Value]): Either[Throwable, B] =
+        self.to(fieldName, value).right.flatMap(a => f(a).to(fieldName, value))
     }
 
     /**

--- a/core/src/main/scala/neotypes/utils.scala
+++ b/core/src/main/scala/neotypes/utils.scala
@@ -80,13 +80,13 @@ private[neotypes] object utils {
       loop(acc = Vector.empty)
     }
 
-    def traverseAsMap[A, B](iter: Iterator[A])
-                           (f: A => (String, Either[Throwable, B])): Either[Throwable, Map[String, B]] = {
+    def traverseAsMap[A, K, V](iter: Iterator[A])
+                              (f: A => Either[Throwable, (K, V)]): Either[Throwable, Map[K, V]] = {
       @annotation.tailrec
-      def loop(acc: Map[String, B]): Either[Throwable, Map[String, B]] =
+      def loop(acc: Map[K, V]): Either[Throwable, Map[K, V]] =
         if (iter.hasNext) f(iter.next()) match {
-          case (key, Right(value)) => loop(acc = acc + (key -> value))
-          case (_,   Left(e))      => Left(e)
+          case Right((key, value)) => loop(acc = acc + (key -> value))
+          case Left(e)             => Left(e)
         } else {
           Right(acc)
         }

--- a/core/src/main/scala/neotypes/utils.scala
+++ b/core/src/main/scala/neotypes/utils.scala
@@ -67,6 +67,19 @@ private[neotypes] object utils {
       loop(acc = Set.empty)
     }
 
+    def traverseAsVector[A, B](iter: Iterator[A])
+                              (f: A => Either[Throwable, B]): Either[Throwable, Vector[B]] = {
+      @annotation.tailrec
+      def loop(acc: Vector[B]): Either[Throwable, Vector[B]] =
+        if (iter.hasNext) f(iter.next()) match {
+          case Right(value) => loop(acc = acc :+ value)
+          case Left(e)      => Left(e)
+        } else {
+          Right(acc)
+        }
+      loop(acc = Vector.empty)
+    }
+
     def traverseAsMap[A, B](iter: Iterator[A])
                            (f: A => (String, Either[Throwable, B])): Either[Throwable, Map[String, B]] = {
       @annotation.tailrec

--- a/core/src/test/scala/neotypes/BaseIntegrationSpec.scala
+++ b/core/src/test/scala/neotypes/BaseIntegrationSpec.scala
@@ -5,10 +5,11 @@ import java.time.Duration
 import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
 import org.neo4j.driver.v1
 import org.neo4j.driver.v1.{GraphDatabase, TransactionWork}
-import org.scalatest.Suite
+import org.scalatest.AsyncFlatSpec
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy
 
-trait BaseIntegrationSpec extends Suite with ForAllTestContainer {
+/** Base class for simple integration specs. */
+abstract class BaseIntegrationSpec extends AsyncFlatSpec with ForAllTestContainer {
   def initQuery: String
 
   override val container = GenericContainer("neo4j:3.5.3",
@@ -42,4 +43,10 @@ object BaseIntegrationSpec {
       |CREATE (Charlize)-[:ACTED_IN {roles:['Tina']}]->(ThatThingYouDo)
       |CREATE (t:Test {added: date('2018-11-26')})
       |CREATE (ThatThingYouDo)-[:TEST_EDGE]->(t)""".stripMargin
+
+  final val MULTIPLE_VALUES_INIT_QUERY: String =
+    (0 to 10).map(n => s"CREATE (:Person {name: $n})").mkString("\n")
+
+  final val EMPTY_INIT_QUERY: String =
+    null
 }

--- a/core/src/test/scala/neotypes/BasicSessionSpec.scala
+++ b/core/src/test/scala/neotypes/BasicSessionSpec.scala
@@ -9,9 +9,8 @@ import shapeless._
 import scala.concurrent.Future
 import org.neo4j.driver.v1.Value
 import org.neo4j.driver.v1.types.Node
-import org.scalatest.AsyncFlatSpec
 
-class BasicSessionSpec extends AsyncFlatSpec with BaseIntegrationSpec {
+class BasicSessionSpec extends BaseIntegrationSpec {
   import BasicSessionSpec._
 
   it should "map result to hlist and case classes" in {
@@ -109,13 +108,13 @@ class BasicSessionSpec extends AsyncFlatSpec with BaseIntegrationSpec {
 }
 
 object BasicSessionSpec {
-  case class Person(id: Long, born: Int, name: Option[String], f: Option[Int])
+  final case class Person(id: Long, born: Int, name: Option[String], f: Option[Int])
 
-  case class Person2(born: Int, name: Option[String])
+  final case class Person2(born: Int, name: Option[String])
 
-  case class Movie(id: Long, released: Int, title: String)
+  final case class Movie(id: Long, released: Int, title: String)
 
-  case class Cast(name: String, job: String, role: String)
+  final case class Cast(name: String, job: String, role: String)
 
-  case class Movie2(title: String, cast: List[Cast])
+  final case class Movie2(title: String, cast: List[Cast])
 }

--- a/core/src/test/scala/neotypes/CleaningIntegrationSpec.scala
+++ b/core/src/test/scala/neotypes/CleaningIntegrationSpec.scala
@@ -1,0 +1,23 @@
+package neotypes
+
+import neotypes.implicits.mappers.executions._
+import neotypes.implicits.syntax.driver._
+import neotypes.implicits.syntax.string._
+import org.scalatest.FutureOutcome
+
+import scala.concurrent.Future
+
+/** Base class for integration specs that require to clean the graph after each test. */
+abstract class CleaningIntegrationSpec extends BaseIntegrationSpec {
+  override final def withFixture(test: NoArgAsyncTest): FutureOutcome = {
+    val f = for {
+      r <- super.withFixture(test).toFuture
+      _ <- driver.asScala[Future].writeSession { s =>
+             "MATCH (n) DETACH DELETE n".query[Unit].execute(s)
+           }
+    } yield r
+    new FutureOutcome(f)
+  }
+
+  override final val initQuery: String = BaseIntegrationSpec.EMPTY_INIT_QUERY
+}

--- a/core/src/test/scala/neotypes/MapperSpec.scala
+++ b/core/src/test/scala/neotypes/MapperSpec.scala
@@ -7,8 +7,7 @@ import org.neo4j.driver.v1.Value
 import org.scalatest.FreeSpec
 
 class MapperSpec extends FreeSpec {
-
-  case class MyCaseClass(value: String)
+  import MapperSpec.MyCaseClass
 
   "ResultMapper" - {
     "constructors" - {
@@ -138,4 +137,8 @@ class MapperSpec extends FreeSpec {
       assert(resultString == Right(Right("string")))
     }
   }
+}
+
+object MapperSpec {
+  final case class MyCaseClass(value: String)
 }

--- a/core/src/test/scala/neotypes/ParameterSpec.scala
+++ b/core/src/test/scala/neotypes/ParameterSpec.scala
@@ -9,12 +9,11 @@ import neotypes.implicits.syntax.session._
 import neotypes.implicits.syntax.string._
 import org.neo4j.driver.v1.{Value, Values}
 import org.neo4j.driver.v1.types.{IsoDuration, Node, Point}
-import org.scalatest.AsyncFlatSpec
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
 
-class ParameterSpec extends AsyncFlatSpec with BaseIntegrationSpec {
+class ParameterSpec extends BaseIntegrationSpec {
   it should "convert parameters" in {
     val s = driver.session().asScala[Future]
 
@@ -88,5 +87,5 @@ class ParameterSpec extends AsyncFlatSpec with BaseIntegrationSpec {
     }
   }
 
-  override val initQuery: String = null
+  override val initQuery: String = BaseIntegrationSpec.EMPTY_INIT_QUERY
 }

--- a/core/src/test/scala/neotypes/ParameterSpec.scala
+++ b/core/src/test/scala/neotypes/ParameterSpec.scala
@@ -14,7 +14,7 @@ import org.scalatest.AsyncFlatSpec
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
 
-class ParameterSessionSpec extends AsyncFlatSpec with BaseIntegrationSpec {
+class ParameterSpec extends AsyncFlatSpec with BaseIntegrationSpec {
   it should "convert parameters" in {
     val s = driver.session().asScala[Future]
 
@@ -25,6 +25,7 @@ class ParameterSessionSpec extends AsyncFlatSpec with BaseIntegrationSpec {
     val data: Array[Byte] = Array(0, 0, 1, 1)
     val list: List[Double] = List(5.0, 10.10)
     val set: Set[Long] = Set(100L)
+    val vector: Vector[Long] = Vector(333L)
     val map: Map[String, Float] = Map("f" -> -1.5f)
     val localDate: LocalDate = LocalDate.now()
     val localDateTime: LocalDateTime = LocalDateTime.now()
@@ -48,6 +49,7 @@ class ParameterSessionSpec extends AsyncFlatSpec with BaseIntegrationSpec {
                  data: $data,
                  list: $list,
                  set: $set,
+                 vector: $vector,
                  localDate: $localDate,
                  localDateTime: $localDateTime,
                  localTime: $localTime,
@@ -70,6 +72,7 @@ class ParameterSessionSpec extends AsyncFlatSpec with BaseIntegrationSpec {
       assert(res.get("data").asByteArray.deep == data.deep)
       assert(res.get("list").asList.asScala.toList == list)
       assert(res.get("set").asList.asScala.toSet == set)
+      assert(res.get("vector").asList.asScala.toVector == vector)
       assert(res.get("localDate").asLocalDate == localDate)
       assert(res.get("localDateTime").asLocalDateTime == localDateTime)
       assert(res.get("localTime").asLocalTime == localTime)

--- a/core/src/test/scala/neotypes/PathSessionSpec.scala
+++ b/core/src/test/scala/neotypes/PathSessionSpec.scala
@@ -5,12 +5,11 @@ import neotypes.implicits.syntax.session._
 import neotypes.implicits.syntax.string._
 import org.neo4j.driver.v1.types.{Node, Relationship}
 import shapeless._
-import PathSessionSpec._
-import org.scalatest.AsyncFlatSpec
 
 import scala.concurrent.Future
 
-class PathSessionSpec extends AsyncFlatSpec with BaseIntegrationSpec {
+class PathSessionSpec extends BaseIntegrationSpec {
+  import PathSessionSpec.Person
 
   it should "map path to Seq" in {
     val s = driver.session().asScala[Future]
@@ -24,19 +23,10 @@ class PathSessionSpec extends AsyncFlatSpec with BaseIntegrationSpec {
       assert(pathHList.last.nodes.size == 2)
     }
   }
-  override val initQuery: String = PathSessionSpec.INIT_QUERY
+
+  override val initQuery: String = BaseIntegrationSpec.DEFAULT_INIT_QUERY
 }
 
 object PathSessionSpec {
-
-  case class Person(name: String)
-
-  val INIT_QUERY =
-    """
-      |CREATE (Charlize:Person {name:'Charlize Theron', born:1975})
-      |CREATE (ThatThingYouDo:Movie {title:'That Thing You Do', released:1996, tagline:'In every life there comes a time when that thing you dream becomes that thing you do'})
-      |CREATE (Charlize)-[:ACTED_IN {roles:['Tina']}]->(ThatThingYouDo)
-      |CREATE (t:Test {added: date('2018-11-26')})
-      |CREATE (ThatThingYouDo)-[:TEST_EDGE]->(t)
-    """.stripMargin
+  final case class Person(name: String)
 }

--- a/core/src/test/scala/neotypes/QueryExecutionSpec.scala
+++ b/core/src/test/scala/neotypes/QueryExecutionSpec.scala
@@ -1,0 +1,46 @@
+package neotypes
+
+import neotypes.implicits.mappers.results._
+import neotypes.implicits.syntax.session._
+import neotypes.implicits.syntax.string._
+import org.scalatest.AsyncFlatSpec
+
+import scala.concurrent.Future
+
+class QueryExecutionSpec extends AsyncFlatSpec with BaseIntegrationSpec {
+  it should "retrieve multiple results as a List" in {
+    val s = driver.session().asScala[Future]
+
+    "match (p:Person) return p.name"
+      .query[Int]
+      .list(s)
+      .map {
+        names => assert(names == (0 to 10).toList)
+      }
+  }
+
+  it should "retrieve multiple results as a Set" in {
+    val s = driver.session().asScala[Future]
+
+    "match (p:Person) return p.name"
+      .query[Int]
+      .set(s)
+      .map {
+        names => assert(names == (0 to 10).toSet)
+      }
+  }
+
+  it should "retrieve multiple results as a Vector" in {
+    val s = driver.session().asScala[Future]
+
+    "match (p:Person) return p.name"
+      .query[Int]
+      .vector(s)
+      .map {
+        names => assert(names == (0 to 10).toVector)
+      }
+  }
+
+  override def initQuery: String =
+    (0 to 10).map(n => s"CREATE (:Person {name: $n})").mkString("\n")
+}

--- a/core/src/test/scala/neotypes/QueryExecutionSpec.scala
+++ b/core/src/test/scala/neotypes/QueryExecutionSpec.scala
@@ -41,6 +41,16 @@ class QueryExecutionSpec extends AsyncFlatSpec with BaseIntegrationSpec {
       }
   }
 
-  override def initQuery: String =
-    (0 to 10).map(n => s"CREATE (:Person {name: $n})").mkString("\n")
+  it should "retrieve multiple results as a Map" in {
+    val s = driver.session().asScala[Future]
+
+    "match (p:Person) return p.name, 1"
+      .query[(Int, Int)]
+      .map(s)
+      .map {
+        names => assert(names == (0 to 10).map(k => k -> 1).toMap)
+      }
+  }
+
+  override def initQuery: String = BaseIntegrationSpec.MULTIPLE_VALUES_INIT_QUERY
 }

--- a/core/src/test/scala/neotypes/QueryExecutionSpec.scala
+++ b/core/src/test/scala/neotypes/QueryExecutionSpec.scala
@@ -3,11 +3,10 @@ package neotypes
 import neotypes.implicits.mappers.results._
 import neotypes.implicits.syntax.session._
 import neotypes.implicits.syntax.string._
-import org.scalatest.AsyncFlatSpec
 
 import scala.concurrent.Future
 
-class QueryExecutionSpec extends AsyncFlatSpec with BaseIntegrationSpec {
+class QueryExecutionSpec extends BaseIntegrationSpec {
   it should "retrieve multiple results as a List" in {
     val s = driver.session().asScala[Future]
 

--- a/docs/src/main/tut/docs.md
+++ b/docs/src/main/tut/docs.md
@@ -9,13 +9,14 @@ title: "Documentation"
 
 * Scala 2.12/2.11
 * Java 8+
-* neo4j 3.*.*+
+* neo4j 3+
 
 ## Session creation
 
 **neotypes** adds an extension method (`.asScala[F[_]: Async]`) to `org.neo4j.driver.v1.Session` and `org.neo4j.driver.v1.Driver` that allows to build a `neotypes`'s session and driver wrappers.
 You can parametrize `asScala` by any type that you have a typeclass `neotypes.Async` implementation for.
-The typeclass implementation for `scala.concurrent.Future` is built-in (Please read more about [side effect implementations](docs/alternative_effects.html).
+The typeclass implementation for `scala.concurrent.Future` is built-in _(please read more about [side effect implementations](docs/alternative_effects.html))_.
+
 Please note that you have to make sure that the session is properly closed at the end of the application execution if you decide to manage session lifecycle manually.
 
 ```scala
@@ -58,13 +59,16 @@ val born = 1980
 c"create (p:Person {name: $name, born: $born})".query[Unit].execute(s) // Query with string interpolation.
 ```
 
-A query can be run in three different ways:
+A query can be run in five different ways:
 
 * `execute(s)` - executes a query that has no return data. Query can be parametrized by `org.neo4j.driver.v1.summary.ResultSummary` or `Unit`.
 If you need to support your return types for this type of queries, you can provide an implementation of `ExecutionMapper` for any custom type.
-* `single(s)` - runs a query and return a single result.
-* `list(s)` - runs a query and returns a list of results.
-* `set(s)` - runs a query and returns a set of results.
+* `single(s)` - runs a query and return a **single** result.
+* `list(s)` - runs a query and returns a **List** of results.
+* `set(s)` - runs a query and returns a **Set** of results.
+* `vector(s)` - runs a query and returns a **Vector** of results.
+* `stream(s)` - runs a query and returns a **Stream** of results
+_(please read more [streaming](docs/streams.html))_.
 
 ```scala
 // Execute.
@@ -83,4 +87,8 @@ If you need to support your return types for this type of queries, you can provi
 // Set.
 "match (p:Person {name: 'Charlize Theron'})-[]->(m:Movie) return p,m".query[Person :: Movie :: HNil].set(s)
 "match (p:Person {name: 'Charlize Theron'})-[]->(m:Movie) return p,m".query[(Person, Movie)].set(s)
+
+// Vector.
+"match (p:Person {name: 'Charlize Theron'})-[]->(m:Movie) return p,m".query[Person :: Movie :: HNil].vector(s)
+"match (p:Person {name: 'Charlize Theron'})-[]->(m:Movie) return p,m".query[(Person, Movie)].vector(s)
 ```

--- a/docs/src/main/tut/docs.md
+++ b/docs/src/main/tut/docs.md
@@ -59,7 +59,7 @@ val born = 1980
 c"create (p:Person {name: $name, born: $born})".query[Unit].execute(s) // Query with string interpolation.
 ```
 
-A query can be run in five different ways:
+A query can be run in six different ways:
 
 * `execute(s)` - executes a query that has no return data. Query can be parametrized by `org.neo4j.driver.v1.summary.ResultSummary` or `Unit`.
 If you need to support your return types for this type of queries, you can provide an implementation of `ExecutionMapper` for any custom type.
@@ -67,6 +67,7 @@ If you need to support your return types for this type of queries, you can provi
 * `list(s)` - runs a query and returns a **List** of results.
 * `set(s)` - runs a query and returns a **Set** of results.
 * `vector(s)` - runs a query and returns a **Vector** of results.
+* `map(s)` - runs a query and returns a **Map** of results _(only if the elements are tuples)_.
 * `stream(s)` - runs a query and returns a **Stream** of results
 _(please read more [streaming](docs/streams.html))_.
 
@@ -91,4 +92,7 @@ _(please read more [streaming](docs/streams.html))_.
 // Vector.
 "match (p:Person {name: 'Charlize Theron'})-[]->(m:Movie) return p,m".query[Person :: Movie :: HNil].vector(s)
 "match (p:Person {name: 'Charlize Theron'})-[]->(m:Movie) return p,m".query[(Person, Movie)].vector(s)
+
+// Map.
+"match (p:Person {name: 'Charlize Theron'})-[]->(m:Movie) return p,m".query[(Person, Movie)].map(s)
 ```

--- a/docs/src/main/tut/docs/alternative_effects.md
+++ b/docs/src/main/tut/docs/alternative_effects.md
@@ -24,7 +24,7 @@ Await.result("match (p:Person {name: 'Charlize Theron'}) return p.name".query[St
 
 ```scala
 import cats.effect.IO
-import neotypes.cats.implicits._ // Brings the implicit Async[IO] instance into the scope.
+import neotypes.cats.effect.implicits._ // Brings the implicit Async[IO] instance into the scope.
 import neotypes.implicits.mappers.results._ // Brings the implicit ResultMapper[String] instance into the scope.
 import neotypes.implicits.syntax.session._ // Provides the asScala[F[_]] extension method.
 import neotypes.implicits.syntax.string._ // Provides the query[T] extension method.

--- a/docs/src/main/tut/docs/streams.md
+++ b/docs/src/main/tut/docs/streams.md
@@ -39,7 +39,7 @@ implicit val materializer = ActorMaterializer()
 
 ```scala
 import cats.effect.IO
-import neotypes.cats.implicits._ // Brings the implicit Async[IO] instance into the scope.
+import neotypes.cats.effect.implicits._ // Brings the implicit Async[IO] instance into the scope.
 import neotypes.fs2.Fs2IoStream
 import neotypes.fs2.implicits._ // Brings the implicit Stream[Fs2IOStream] instance into the scope.
 import neotypes.implicits.mappers.results._ // Brings the implicit ResultMapper[String] instance into the scope.
@@ -60,7 +60,7 @@ val s = driver.session().asScala[IO]
 #### With other effect type.
 
 ```scala
-import neotypes.cats.implicits._ // Brings the implicit Async[F[_]] instance into the scope.
+import neotypes.cats.effect.implicits._ // Brings the implicit Async[F[_]] instance into the scope.
 import neotypes.fs2.Fs2FStream
 import neotypes.fs2.implicits._ // Brings the implicit Stream[Fs2FStream] instance into the scope.
 import neotypes.implicits.mappers.results._ // Brings the implicit ResultMapper[String] instance into the scope.

--- a/docs/src/main/tut/docs/types.md
+++ b/docs/src/main/tut/docs/types.md
@@ -8,41 +8,49 @@ title: "Supported types"
 {:.table}
 | Type                                      | Query result   | Field of a case class | Query parameter |
 | ----------------------------------------- |:--------------:|:---------------------:|:-----------------|
-| `scala.Boolean                         `  | ✓              |✓                      |✓|
-| `scala.Int                             `  | ✓              |✓                      |✓|
-| `scala.Long                            `  | ✓              |✓                      |✓|
-| `scala.Double                          `  | ✓              |✓                      |✓|
-| `scala.Float                           `  | ✓              |✓                      |✓|
-| `java.lang.String                      `  | ✓              |✓                      |✓|
-| `scala.Array[Byte]                     `  | ✓              |✓                      |✓|
-| `scala.Option[T] *                     `  | ✓              |✓                      |✓ `**`|
-| `scala.List[T] *                       `  | ✓              |✓                      |✓|
-| `scala.Set[T] *                        `  | ✓              |✓                      |✓|
-| `scala.Vector[T] *                     `  | ✓              |✓                      |✓|
-| `scala.Map[String, T] *                `  | ✓              |✓                      |✓|
-| `refined.Refined[T, P] * ***           `  | ✓              |✓                      |✓|
-| `java.time.Duration                    `  | ✓              |✓                      |✓|
-| `java.time.LocalDate                   `  | ✓              |✓                      |✓|
-| `java.time.LocalDateTime               `  | ✓              |✓                      |✓|
-| `java.time.LocalTime                   `  | ✓              |✓                      |✓|
-| `java.time.Period                      `  | ✓              |✓                      |✓|
-| `java.time.OffsetDateTime              `  | ✓              |✓                      |✓|
-| `java.time.OffsetTime                  `  | ✓              |✓                      |✓|
-| `java.time.ZonedDateTime               `  | ✓              |✓                      |✓|
-| `java.util.UUID                        `  | ✓              |✓                      |✓|
-| `org.neo4j.driver.v1.Value             `  | ✓              |✓                      |✓|
-| `org.neo4j.driver.v1.types.IsoDuration `  | ✓              |✓                      |✓|
-| `org.neo4j.driver.v1.types.Point       `  | ✓              |✓                      |✓|
-| `org.neo4j.driver.v1.types.Node        `  | ✓              |✓                      ||
-| `org.neo4j.driver.v1.types.Relationship`  | ✓              |✓                      ||
-| `shapeless.HList                       `  | ✓              |                       ||
-| `neotypes.types.Path                   `  | ✓              |                       ||
-| `Tuple (1-22)                          `  | ✓              |                       ||
-| `User defined case class               `  | ✓              |                       ||
+| `scala.Boolean                           `  | ✓              |✓                      |✓|
+| `scala.Int                               `  | ✓              |✓                      |✓|
+| `scala.Long                              `  | ✓              |✓                      |✓|
+| `scala.Double                            `  | ✓              |✓                      |✓|
+| `scala.Float                             `  | ✓              |✓                      |✓|
+| `java.lang.String                        `  | ✓              |✓                      |✓|
+| `scala.Array[Byte]                       `  | ✓              |✓                      |✓|
+| `scala.Option[T] *                       `  | ✓              |✓                      |✓ `**`|
+| `scala.List[T] *                         `  | ✓              |✓                      |✓|
+| `scala.Set[T] *                          `  | ✓              |✓                      |✓|
+| `scala.Vector[T] *                       `  | ✓              |✓                      |✓|
+| `scala.Map[String, T] *                  `  | ✓              |✓                      |✓|
+| `refined.Refined[T, P] * ***             `  | ✓              |✓                      |✓|
+| `cats.data.Chain[T] * ****               `  | ✓              |✓                      |✓|
+| `cats.data.Const[T, U] * ****            `  | ✓              |✓                      |✓|
+| `cats.data.NonEmptyChain[T] * ****       `  | ✓              |✓                      |✓|
+| `cats.data.NonEmptyList[T] * ****        `  | ✓              |✓                      |✓|
+| `cats.data.NonEmptyMap[String, T] * **** `  | ✓              |✓                      |✓|
+| `cats.data.NonEmptySet[T] * ****         `  | ✓              |✓                      |✓|
+| `cats.data.NonEmptyVector[T] * ****      `  | ✓              |✓                      |✓|
+| `java.time.Duration                      `  | ✓              |✓                      |✓|
+| `java.time.LocalDate                     `  | ✓              |✓                      |✓|
+| `java.time.LocalDateTime                 `  | ✓              |✓                      |✓|
+| `java.time.LocalTime                     `  | ✓              |✓                      |✓|
+| `java.time.Period                        `  | ✓              |✓                      |✓|
+| `java.time.OffsetDateTime                `  | ✓              |✓                      |✓|
+| `java.time.OffsetTime                    `  | ✓              |✓                      |✓|
+| `java.time.ZonedDateTime                 `  | ✓              |✓                      |✓|
+| `java.util.UUID                          `  | ✓              |✓                      |✓|
+| `org.neo4j.driver.v1.Value               `  | ✓              |✓                      |✓|
+| `org.neo4j.driver.v1.types.IsoDuration   `  | ✓              |✓                      |✓|
+| `org.neo4j.driver.v1.types.Point         `  | ✓              |✓                      |✓|
+| `org.neo4j.driver.v1.types.Node          `  | ✓              |✓                      ||
+| `org.neo4j.driver.v1.types.Relationship  `  | ✓              |✓                      ||
+| `shapeless.HList                         `  | ✓              |                       ||
+| `neotypes.types.Path                     `  | ✓              |                       ||
+| `Tuple (1-22)                            `  | ✓              |                       ||
+| `User defined case class                 `  | ✓              |                       ||
 
 > `*` Generic types are supported as long as the the `T` is also supported.<br>
 > `**` `None` is converted into `null`.<br>
-> `***` Support is provided in the **neotypes-refined** _module_.
+> `***` Support is provided in the **neotypes-refined** _module_.<br>
+> `****` Support is provided in the **neotypes-cats-data** _module_.<br>
 
 ## Additional types
 

--- a/docs/src/main/tut/docs/types.md
+++ b/docs/src/main/tut/docs/types.md
@@ -18,6 +18,7 @@ title: "Supported types"
 | `scala.Option[T] *                     `  | ✓              |✓                      |✓ `**`|
 | `scala.List[T] *                       `  | ✓              |✓                      |✓|
 | `scala.Set[T] *                        `  | ✓              |✓                      |✓|
+| `scala.Vector[T] *                     `  | ✓              |✓                      |✓|
 | `scala.Map[String, T] *                `  | ✓              |✓                      |✓|
 | `refined.Refined[T, P] * ***           `  | ✓              |✓                      |✓|
 | `java.time.Duration                    `  | ✓              |✓                      |✓|

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -43,3 +43,4 @@ The project aims to provide seamless integration with most popular scala infrast
 |`"com.dimafeng" %% "neotypes-monix-stream" % version`|result streaming for Monix Observables.|
 |`"com.dimafeng" %% "neotypes-zio-stream" % version`|result streaming for ZIO ZStreams.|
 |`"com.dimafeng" %% "neotypes-refined" % version`|support to insert and retrieve refined values.|
+|`"com.dimafeng" %% "neotypes-cats-data" % version`|support to insert and retrieve `cats.data` values.|

--- a/fs2-stream/src/test/scala/neotypes/fs2/Fs2StreamSpec.scala
+++ b/fs2-stream/src/test/scala/neotypes/fs2/Fs2StreamSpec.scala
@@ -2,7 +2,7 @@ package neotypes.fs2
 
 import cats.effect.IO
 import neotypes.BaseIntegrationSpec
-import neotypes.cats.implicits._
+import neotypes.cats.effect.implicits._
 import neotypes.fs2.implicits._
 import neotypes.implicits.mappers.results._
 import neotypes.implicits.syntax.session._

--- a/fs2-stream/src/test/scala/neotypes/fs2/Fs2StreamSpec.scala
+++ b/fs2-stream/src/test/scala/neotypes/fs2/Fs2StreamSpec.scala
@@ -7,9 +7,8 @@ import neotypes.fs2.implicits._
 import neotypes.implicits.mappers.results._
 import neotypes.implicits.syntax.session._
 import neotypes.implicits.syntax.string._
-import org.scalatest.AsyncFlatSpec
 
-class Fs2StreamSpec extends AsyncFlatSpec with BaseIntegrationSpec {
+class Fs2StreamSpec extends BaseIntegrationSpec {
   it should "work with fs2 using cats.effect.IO" in {
     val s = driver.session().asScala[IO]
 
@@ -24,6 +23,5 @@ class Fs2StreamSpec extends AsyncFlatSpec with BaseIntegrationSpec {
       }
   }
 
-  override val initQuery: String =
-    (0 to 10).map(n => s"CREATE (:Person {name: $n})").mkString("\n")
+  override val initQuery: String = BaseIntegrationSpec.MULTIPLE_VALUES_INIT_QUERY
 }

--- a/monix-stream/src/test/scala/neotypes/monix/stream/MonixStreamSpec.scala
+++ b/monix-stream/src/test/scala/neotypes/monix/stream/MonixStreamSpec.scala
@@ -8,9 +8,8 @@ import neotypes.implicits.syntax.session._
 import neotypes.implicits.syntax.string._
 import neotypes.monix.implicits._
 import neotypes.monix.stream.implicits._
-import org.scalatest.AsyncFlatSpec
 
-class MonixStreamSpec extends AsyncFlatSpec with BaseIntegrationSpec {
+class MonixStreamSpec extends BaseIntegrationSpec {
   it should "work with monix.reactive.Observable" in {
     val s = driver.session().asScala[Task]
 
@@ -24,6 +23,5 @@ class MonixStreamSpec extends AsyncFlatSpec with BaseIntegrationSpec {
       }
   }
 
-  override val initQuery: String =
-    (0 to 10).map(n => s"CREATE (:Person {name: $n})").mkString("\n")
+  override val initQuery: String = BaseIntegrationSpec.MULTIPLE_VALUES_INIT_QUERY
 }

--- a/monix/src/test/scala/neotypes/monix/MonixAsyncSpec.scala
+++ b/monix/src/test/scala/neotypes/monix/MonixAsyncSpec.scala
@@ -8,9 +8,8 @@ import neotypes.implicits.syntax.string._
 import neotypes.monix.implicits._
 import neotypes.BaseIntegrationSpec
 import org.neo4j.driver.v1.exceptions.ClientException
-import org.scalatest.AsyncFlatSpec
 
-class MonixAsyncSpec extends AsyncFlatSpec with BaseIntegrationSpec {
+class MonixAsyncSpec extends BaseIntegrationSpec {
   it should "work with Task" in {
     val s = driver.session().asScala[Task]
 

--- a/refined/src/test/scala/neotypes/refined/RefinedSpec.scala
+++ b/refined/src/test/scala/neotypes/refined/RefinedSpec.scala
@@ -1,9 +1,8 @@
 package neotypes.refined
 
-import neotypes.BaseIntegrationSpec
+import neotypes.CleaningIntegrationSpec
 import neotypes.exceptions.UncoercibleException
 import neotypes.implicits.mappers.all._
-import neotypes.implicits.syntax.driver._
 import neotypes.implicits.syntax.cypher._
 import neotypes.implicits.syntax.session._
 import neotypes.implicits.syntax.string._
@@ -13,26 +12,11 @@ import eu.timepit.refined.W
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric.Interval
-import org.scalatest.FreeSpec
-import org.scalatest.{AsyncFlatSpec, FutureOutcome}
 
 import scala.concurrent.Future
 
-class RefinedSpec extends AsyncFlatSpec with BaseIntegrationSpec {
+class RefinedSpec extends CleaningIntegrationSpec {
   import RefinedSpec.{Level, User}
-
-  // Clean the graph after each test.
-  override def withFixture(test: NoArgAsyncTest): FutureOutcome = {
-    val f = for {
-      r <- super.withFixture(test).toFuture
-      _ <- driver.asScala[Future].writeSession { s =>
-             "MATCH (n) DETACH DELETE n".query[Unit].execute(s)
-           }
-    } yield r
-    new FutureOutcome(f)
-  }
-
-  override val initQuery: String = RefinedSpec.INIT_QUERY
 
   it should "insert and retrieve one refined value" in {
     val s = driver.session().asScala[Future]
@@ -131,6 +115,4 @@ object RefinedSpec {
   type Level = Int Refined Interval.Closed[W.`1`.T, W.`99`.T]
 
   final case class User(name: String, level: Level)
-
-  val INIT_QUERY: String = null
 }

--- a/refined/src/test/scala/neotypes/refined/RefinedSpec.scala
+++ b/refined/src/test/scala/neotypes/refined/RefinedSpec.scala
@@ -55,7 +55,7 @@ class RefinedSpec extends CleaningIntegrationSpec {
     } yield assert(values == levels)
   }
 
-  it should "insert and retrieve refined values inside a case class" in {
+  it should "retrieve refined values inside a case class" in {
     val s = driver.session().asScala[Future]
 
     for {

--- a/zio-stream/src/test/scala/neotypes/zio/stream/ZioStreamSpec.scala
+++ b/zio-stream/src/test/scala/neotypes/zio/stream/ZioStreamSpec.scala
@@ -8,9 +8,8 @@ import neotypes.implicits.syntax.session._
 import neotypes.implicits.syntax.string._
 import neotypes.zio.implicits._
 import neotypes.zio.stream.implicits._
-import org.scalatest.AsyncFlatSpec
 
-class ZioStreamSpec extends AsyncFlatSpec with BaseIntegrationSpec {
+class ZioStreamSpec extends BaseIntegrationSpec {
   it should "work with zio.ZStream" in {
     val runtime = new DefaultRuntime {}
 
@@ -29,6 +28,5 @@ class ZioStreamSpec extends AsyncFlatSpec with BaseIntegrationSpec {
       }
   }
 
-  override val initQuery: String =
-    (0 to 10).map(n => s"CREATE (:Person {name: $n})").mkString("\n")
+  override val initQuery: String = BaseIntegrationSpec.MULTIPLE_VALUES_INIT_QUERY
 }

--- a/zio/src/test/scala/neotypes/zio/ZioAsyncSpec.scala
+++ b/zio/src/test/scala/neotypes/zio/ZioAsyncSpec.scala
@@ -8,9 +8,8 @@ import neotypes.implicits.syntax.string._
 import neotypes.zio.implicits._
 import neotypes.BaseIntegrationSpec
 import org.neo4j.driver.v1.exceptions.ClientException
-import org.scalatest.AsyncFlatSpec
 
-class ZioAsyncSpec extends AsyncFlatSpec with BaseIntegrationSpec {
+class ZioAsyncSpec extends BaseIntegrationSpec {
   it should "work with ZIO" in {
     val runtime = new DefaultRuntime {}
 


### PR DESCRIPTION
Ok, so this is another **big** PR...
_(I am sorry, I know those are hard to review, but it was too convenient to do all these at once.)_

This PR include 5 changes _(each per commit)_:

+ Adding support for `Vector`:
  - As a field of a case class _(`ValueMapper`)_.
  - As a query result _(`ResultMapper`)_.
  - As a parameter _(`ParameterMapper`)_.
  - As a query execution _(method in `Transaction` & `DeferredQuery`)_.

+ Adding support for `Map` as a query execution _(method in `Transaction` & `DeferredQuery`)_.
   Only if `T <:< (K, V)`.

+ Reducing a little bit of boilerplate in the tests.

+ Moving the **cats-effect** implicits from `neotypes.cats.implicits._` to `neotypes.cats.effect.implicits._`.
    _(This is another breaking change!!)_

+ Adding a new module **neotypes-cats-data** which provides support for various types inside the `cats.data` package.

  -  `Chain`
  - `Const`
  - `NonEmptyChain`
  - `NonEmptyList`
  - `NonEmptyMap`
  - `NonEmptySet`
  - `NonEmptyVector`


@dimafeng 

> **PS:** As I already said, each commit should have been in its own PR. Thus, I believe it would be easier to review if instead of looking at all changes at once, you check commit by commit.