### PR TITLE
Low priority trick + cats implicits test

### DIFF
--- a/cats-effect/src/main/scala/neotypes/cats/implicits.scala
+++ b/cats-effect/src/main/scala/neotypes/cats/implicits.scala
@@ -1,7 +1,9 @@
 package neotypes.cats
 
-object implicits {
-  implicit def catsAsync[F[_]](implicit F: cats.effect.Async[F]): neotypes.Async[F] =
+object implicits extends CatsInstances
+
+private[cats] abstract class CatsInstances {
+ implicit def catsAsync[F[_]](implicit F: cats.effect.Async[F]): neotypes.Async[F] =
     new neotypes.Async[F] {
       override def async[T](cb: (Either[Throwable, T] => Unit) => Unit): F[T] =
         F.async(cb)

--- a/cats-effect/src/test/scala/neotypes/cats/CatsImplicitsSpec.scala
+++ b/cats-effect/src/test/scala/neotypes/cats/CatsImplicitsSpec.scala
@@ -1,0 +1,44 @@
+package neotypes.cats
+
+import cats.Applicative
+import cats.effect._
+import cats.effect.implicits._
+import cats.implicits._
+import neotypes.cats.implicits._
+import neotypes.Async._
+import neotypes.implicits._
+import neotypes.implicits.all._
+import neotypes.{BaseIntegrationSpec, Session}
+import org.neo4j.driver.v1.exceptions.ClientException
+import org.scalatest.AsyncFlatSpec
+import cats.Monad
+
+class CatsImplicitsSpec extends AsyncFlatSpec with BaseIntegrationSpec {
+  it should "work with cats implicits and neotypes implicits" in {
+    def test1[F[_]: Applicative]: F[Unit] = Applicative[F].unit
+
+    def test2[F[_]: Monad]: F[Unit] = ().pure[F]
+
+    def makeSession[F[_]: Async]: F[Session[F]] =
+      (test1[F] *> test2[F]).as(driver.session().asScala[F])
+
+    val s = makeSession[IO].unsafeRunSync()
+
+    """match (p:Person {name: "Charlize Theron"}) return p.name"""
+      .query[String]
+      .single(s)
+      .unsafeToFuture()
+      .map {
+        name => assert(name == "Charlize Theron")
+      }
+
+    recoverToSucceededIf[ClientException] {
+      "match test return p.name"
+        .query[String]
+        .single(s)
+        .unsafeToFuture()
+    }
+  }
+
+  override val initQuery: String = BaseIntegrationSpec.DEFAULT_INIT_QUERY
+}

--- a/cats-effect/src/test/scala/neotypes/cats/CatsImplicitsSpec.scala
+++ b/cats-effect/src/test/scala/neotypes/cats/CatsImplicitsSpec.scala
@@ -14,13 +14,14 @@ import org.scalatest.AsyncFlatSpec
 import cats.Monad
 
 class CatsImplicitsSpec extends AsyncFlatSpec with BaseIntegrationSpec {
+
   it should "work with cats implicits and neotypes implicits" in {
     def test1[F[_]: Applicative]: F[Unit] = Applicative[F].unit
 
     def test2[F[_]: Monad]: F[Unit] = ().pure[F]
 
     def makeSession[F[_]: Async]: F[Session[F]] =
-      (test1[F] *> test2[F]).as(driver.session().asScala[F])
+      (test1[F] *> test2[F]).flatMap(_ => driver.session().asScala[F].pure[F])
 
     val s = makeSession[IO].unsafeRunSync()
 


### PR DESCRIPTION
I can confirm #36 is fixed in `master`, not in `0.9.0`. Anyway, I thought a test should be added to validate this is not broken in future changes. 

I also changed the way the instances are declared using what's known as the *low priority trait / abstract class*. Ideally all the other instances should be declared in this way (same as other FP libraries get around divergent implicits while remaining binary compat).

Closes #36 