### PR TITLE
Spelling corrections

### DIFF
--- a/cats-data/src/main/scala/neotypes/cats/data/CatsData.scala
+++ b/cats-data/src/main/scala/neotypes/cats/data/CatsData.scala
@@ -2,7 +2,7 @@ package neotypes
 package cats.data
 
 import internal.utils.traverse.{traverseAs, traverseAsList, traverseAsMap, traverseAsSet, traverseAsVector}
-import exceptions.{PropertyNotFoundException, UncoercibleException}
+import exceptions.{PropertyNotFoundException, IncoercibleException}
 import mappers.{ParameterMapper, ResultMapper, ValueMapper}
 import types.QueryParam
 
@@ -83,7 +83,7 @@ trait CatsData {
             }.flatMap { chain =>
               NonEmptyChain.fromChain(chain) match {
                 case None =>
-                  Left(UncoercibleException("NonEmptyChain from an empty list", None.orNull))
+                  Left(IncoercibleException("NonEmptyChain from an empty list", None.orNull))
 
                 case Some(nonEmptyChain) =>
                   Right(nonEmptyChain)
@@ -113,7 +113,7 @@ trait CatsData {
             }.flatMap { list =>
               NonEmptyList.fromList(list) match {
                 case None =>
-                  Left(UncoercibleException("NonEmptyList from an empty list", None.orNull))
+                  Left(IncoercibleException("NonEmptyList from an empty list", None.orNull))
 
                 case Some(nonEmptyList) =>
                   Right(nonEmptyList)
@@ -145,7 +145,7 @@ trait CatsData {
             }.flatMap { map =>
               NonEmptyMap.fromMap(SortedMap.empty[String, T] ++ map) match {
                 case None =>
-                  Left(UncoercibleException("NonEmptyMap from an empty map", None.orNull))
+                  Left(IncoercibleException("NonEmptyMap from an empty map", None.orNull))
 
                 case Some(nonEmptyMap) =>
                   Right(nonEmptyMap)
@@ -175,7 +175,7 @@ trait CatsData {
             }.flatMap { set =>
               NonEmptySet.fromSet(SortedSet.empty[T](order.toOrdering) | set) match {
                 case None =>
-                  Left(UncoercibleException("NonEmptySet from an empty list", None.orNull))
+                  Left(IncoercibleException("NonEmptySet from an empty list", None.orNull))
 
                 case Some(nonEmptySet) =>
                   Right(nonEmptySet)
@@ -205,7 +205,7 @@ trait CatsData {
             }.flatMap { vector =>
               NonEmptyVector.fromVector(vector) match {
                 case None =>
-                  Left(UncoercibleException("NonEmptyVector from an empty list", None.orNull))
+                  Left(IncoercibleException("NonEmptyVector from an empty list", None.orNull))
 
                 case Some(nonEmptyVector) =>
                   Right(nonEmptyVector)

--- a/cats-data/src/test/scala/neotypes/cats/data/CatsDataSpec.scala
+++ b/cats-data/src/test/scala/neotypes/cats/data/CatsDataSpec.scala
@@ -2,7 +2,7 @@ package neotypes.cats.data
 
 import neotypes.CleaningIntegrationSpec
 import neotypes.cats.data.implicits._
-import neotypes.exceptions.UncoercibleException
+import neotypes.exceptions.IncoercibleException
 import neotypes.implicits.mappers.all._
 import neotypes.implicits.syntax.cypher._
 import neotypes.implicits.syntax.string._
@@ -64,7 +64,7 @@ class CatsDataSpec extends CleaningIntegrationSpec[Future] {
   }
 
   it should "fail if retrieving an empty list as a NonEmptyChain" in execute { s =>
-    recoverToSucceededIf[UncoercibleException] {
+    recoverToSucceededIf[IncoercibleException] {
       for {
         _ <- "CREATE (stackTrace: StackTrace { line: 1, errors: [] })".query[Unit].execute(s)
         stackTrace <- "MATCH (stackTrace: StackTrace) RETURN stackTrace".query[StackTrace].single(s)
@@ -86,7 +86,7 @@ class CatsDataSpec extends CleaningIntegrationSpec[Future] {
   }
 
   it should "fail if retrieving an empty list as a NonEmptyList" in execute { s =>
-    recoverToSucceededIf[UncoercibleException] {
+    recoverToSucceededIf[IncoercibleException] {
       for {
         _ <- "CREATE (player: Player { name: \"Luis\", items: [] })".query[Unit].execute(s)
         player <- "MATCH (player: Player) RETURN player".query[Player].single(s)
@@ -108,7 +108,7 @@ class CatsDataSpec extends CleaningIntegrationSpec[Future] {
   }
 
   it should "fail if retrieving an empty map as a NonEmptyMap" in execute { s =>
-    recoverToSucceededIf[UncoercibleException] {
+    recoverToSucceededIf[IncoercibleException] {
       for {
         properties <- "RETURN {}".query[Properties].single(s)
       } yield properties
@@ -129,7 +129,7 @@ class CatsDataSpec extends CleaningIntegrationSpec[Future] {
   }
 
   it should "fail if retrieving an empty list as a NonEmptySet" in execute { s =>
-    recoverToSucceededIf[UncoercibleException] {
+    recoverToSucceededIf[IncoercibleException] {
       for {
         _ <- "CREATE (set: Set { name: \"favourites\", numbers: [] })".query[Unit].execute(s)
         set <- "MATCH (set: Set) RETURN set".query[MySet].single(s)
@@ -151,7 +151,7 @@ class CatsDataSpec extends CleaningIntegrationSpec[Future] {
   }
 
   it should "fail if retrieving an empty list as a NonEmptyVector" in execute { s =>
-    recoverToSucceededIf[UncoercibleException] {
+    recoverToSucceededIf[IncoercibleException] {
       for {
         _ <- "CREATE (purchase: Purchase { total: 12.5, groceries: [] })".query[Unit].execute(s)
         purchase <- "MATCH (purchase: Purchase) RETURN purchase".query[Purchase].single(s)

--- a/core/src/main/scala-2.12/neotypes/implicits/mappers/CompatibilityMappers.scala
+++ b/core/src/main/scala-2.12/neotypes/implicits/mappers/CompatibilityMappers.scala
@@ -11,20 +11,20 @@ import scala.reflect.ClassTag
 /**
  * This trait contains some implicit conversions that are required
  * to enable the collectAs(Col)(session / tx) method on Scala 2.12.
- * It consists of a group of forwarders to the converions
+ * It consists of a group of forwarders to the conversions
  * defined in the scala-collection-compat library.
  * These convert from companion objects of the collections,
  * to instances of CanBuildFrom (Factory).
  *
- * The propouse of this trait, as well of it being mixed in the
+ * The purpose of this trait, as well of it being mixed in the
  * neotypes.implicits.mappers.results object,
- * is to hide the dependency of the compability library to final users.
+ * is to hide the dependency of the compatibility library to final users.
  * We may as well remove this, and force them to import scala.collection.compat._
  *
- * The original definitions of the convertions can be found here:
+ * The original definitions of the conversions can be found here:
  * https://github.com/scala/scala-collection-compat/blob/master/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala#L47-L86
  */
-trait CompabilityMappers {
+trait CompatibilityMappers {
   private type ImmutableBitSetCC[X] = ({ type L[_] = i.BitSet })#L[X]
   private type MutableBitSetCC[X] = ({ type L[_] = m.BitSet })#L[X]
 

--- a/core/src/main/scala-2.13/neotypes/implicits/mappers/CompatibilityMappers.scala
+++ b/core/src/main/scala-2.13/neotypes/implicits/mappers/CompatibilityMappers.scala
@@ -1,4 +1,4 @@
 package neotypes
 package implicits.mappers
 
-trait CompabilityMappers
+trait CompatibilityMappers

--- a/core/src/main/scala/neotypes/exceptions/Exception.scala
+++ b/core/src/main/scala/neotypes/exceptions/Exception.scala
@@ -10,4 +10,4 @@ final case class ConversionException(message: String) extends NeotypesException(
 
 final case class NoFieldsDefinedException(message: String) extends NeotypesException(message)
 
-final case class UncoercibleException(message: String, cause: Uncoercible) extends NeotypesException(message, Option(cause))
+final case class IncoercibleException(message: String, cause: Uncoercible) extends NeotypesException(message, Option(cause))

--- a/core/src/main/scala/neotypes/implicits/mappers/all.scala
+++ b/core/src/main/scala/neotypes/implicits/mappers/all.scala
@@ -5,4 +5,4 @@ trait AllMappers
   extends ExecutionMappers
   with ParameterMappers
   with ResultMappers
-  with CompabilityMappers
+  with CompatibilityMappers

--- a/core/src/main/scala/neotypes/implicits/mappers/package.scala
+++ b/core/src/main/scala/neotypes/implicits/mappers/package.scala
@@ -4,6 +4,6 @@ package object mappers {
   final object all extends AllMappers
   final object executions extends ExecutionMappers
   final object parameters extends ParameterMappers
-  final object results extends ResultMappers with CompabilityMappers
+  final object results extends ResultMappers with CompatibilityMappers
   final object values extends ValueMappers
 }

--- a/core/src/main/scala/neotypes/implicits/syntax/cypher.scala
+++ b/core/src/main/scala/neotypes/implicits/syntax/cypher.scala
@@ -4,6 +4,6 @@ package implicits.syntax
 import scala.language.implicitConversions
 
 trait CypherSyntax {
-  implicit final def neotypesSyntaxChyperStringInterpolator(sc: StringContext): CypherStringInterpolator =
+  implicit final def neotypesSyntaxCypherStringInterpolator(sc: StringContext): CypherStringInterpolator =
     new CypherStringInterpolator(sc)
 }

--- a/core/src/main/scala/neotypes/mappers.scala
+++ b/core/src/main/scala/neotypes/mappers.scala
@@ -1,6 +1,6 @@
 package neotypes
 
-import exceptions.{PropertyNotFoundException, UncoercibleException}
+import exceptions.{PropertyNotFoundException, IncoercibleException}
 import types.QueryParam
 
 import org.neo4j.driver.v1.Value
@@ -285,7 +285,7 @@ object mappers {
             try {
               Right(f(v))
             } catch {
-              case ex: Uncoercible => Left(UncoercibleException(ex.getLocalizedMessage, ex))
+              case ex: Uncoercible => Left(IncoercibleException(ex.getLocalizedMessage, ex))
               case ex: Throwable   => Left(ex)
             }
 

--- a/core/src/test/scala/neotypes/BasicSessionSpec.scala
+++ b/core/src/test/scala/neotypes/BasicSessionSpec.scala
@@ -43,7 +43,7 @@ class BasicSessionSpec extends BaseIntegrationSpec[Future] {
       assert(emptyResult.isEmpty)
       assert(emptyResultList.isEmpty)
       assert(emptyResultEx == "neotypes.exceptions.PropertyNotFoundException: Property  not found") // TODO test separately
-      assert(notString == "neotypes.exceptions.UncoercibleException: Cannot coerce INTEGER to Java String") // TODO test separately
+      assert(notString == "neotypes.exceptions.IncoercibleException: Cannot coerce INTEGER to Java String") // TODO test separately
       assert(node.head.get("name").asString() == "Charlize Theron")
     }
   }

--- a/docs/src/main/tut/docs/alternative_effects.md
+++ b/docs/src/main/tut/docs/alternative_effects.md
@@ -100,9 +100,9 @@ val data: String = runtime.unsafeRun(program)
 ```
 
 ## Custom effect type
-In order to support your any other effect yupe,
-you need to implement the `neotypes.Async.Aux[F[_], R[_]]` **typeclasses**.
-And add them to the implicit scope.
+In order to support your any other effect type,
+you need to implement the `neotypes.Async.Aux[F[_], R[_]]` **typeclasses**
+and add them to the implicit scope.
 
 The type parameters in the signature indicate:
 

--- a/docs/src/main/tut/docs/driver_session_transaction.md
+++ b/docs/src/main/tut/docs/driver_session_transaction.md
@@ -7,19 +7,19 @@ title: "Driver -> Session -> Transaction"
 
 These three classes are the main points of interactions with a **Neo4j** database.
 
-A `Driver` is basically the conection with the Database _per se_. Usually, you would only need one instance per application, unless you need to connect to two different databases.<br>
+A `Driver` is basically the connection with the Database. Usually, you would only need one instance per application, unless you need to connect to two different databases.<br>
 A `Session` provides a context for performing operations _(`Transactions`)_ over the database. You may need as many as concurrent operations you want to have.
 A `Transaction` is a logical container for an atomic unit of work. Only one transaction may exist in a `Session` at any point in time.
 
 ## Transaction managment
 
-Each `Transaction` has to be started, used and finally either, commited or rollbacked.
+Each `Transaction` has to be started, used and finally either, committed or rolled back.
 
 **neotypes** provides 3 ways of interacting with `Transactions`, designed for different use cases.
 
 ### Single query + automatic commit / rollback.
 
-If you only need to perform one query, and want it to be automatically commited in case of success, or rollbacked in case of failure.
+If you only need to perform one query, and want it to be automatically committed in case of success, or rolled back in case of failure.
 You can use the `Session` directly.
 
 ```scala

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -23,7 +23,7 @@ title: "Home"
 * **Asynchronous** - the driver sits on top of [asynchronous Java driver](https://neo4j.com/blog/beta-release-java-driver-async-api-neo4j/).
 * **Not opinionated on side-effect implementation** - you can use it with any implementation of side-effects of your chose (scala.Future, cats-effect IO, Monix Task, etc) by implementing a simple typeclass. `scala.Future` is implemented and comes out of the box.
 
-The project aims to provide seamless integration with most popular scala infrastructures such as lightbend (Akka, Akka-http, Lagom, etc), typelevel (cats, http4s, etc), twitter (finch, etc)...
+The project aims to provide seamless integration with most popular scala infrastructures such as Lightbend (Akka, Akka-http, Lagom, etc), Typelevel (cats, http4s, etc), Twitter (finch, etc)...
 
 ## Resources
 

--- a/refined/src/main/scala/neotypes/refined/Refined.scala
+++ b/refined/src/main/scala/neotypes/refined/Refined.scala
@@ -1,7 +1,7 @@
 package neotypes
 package refined
 
-import exceptions.{PropertyNotFoundException, UncoercibleException}
+import exceptions.{PropertyNotFoundException, IncoercibleException}
 import mappers.{ParameterMapper, ResultMapper, TypeHint, ValueMapper}
 import types.QueryParam
 
@@ -19,7 +19,7 @@ trait RefinedMappers {
           case Some(value) =>
             mapper
               .to(fieldName, Some(value))
-              .flatMap(t => rt.refine(t).left.map(msg => UncoercibleException(msg, None.orNull)))
+              .flatMap(t => rt.refine(t).left.map(msg => IncoercibleException(msg, None.orNull)))
         }
     }
 

--- a/refined/src/test/scala/neotypes/refined/RefinedSpec.scala
+++ b/refined/src/test/scala/neotypes/refined/RefinedSpec.scala
@@ -1,7 +1,7 @@
 package neotypes.refined
 
 import neotypes.CleaningIntegrationSpec
-import neotypes.exceptions.UncoercibleException
+import neotypes.exceptions.IncoercibleException
 import neotypes.implicits.mappers.all._
 import neotypes.implicits.syntax.cypher._
 import neotypes.implicits.syntax.string._
@@ -56,7 +56,7 @@ class RefinedSpec extends CleaningIntegrationSpec[Future] {
   }
 
   it should "fail if a single value does not satisfy the refinement condition" in execute { s =>
-    recoverToSucceededIf[UncoercibleException] {
+    recoverToSucceededIf[IncoercibleException] {
       for {
         _ <- "CREATE (level: Level { value: -1 })".query[Unit].execute(s)
         level <- "MATCH (level: Level) RETURN level".query[Level].single(s)
@@ -65,7 +65,7 @@ class RefinedSpec extends CleaningIntegrationSpec[Future] {
   }
 
   it should "fail if at least one of multiple values does not satisfy the refinement condition" in execute { s =>
-    recoverToSucceededIf[UncoercibleException] {
+    recoverToSucceededIf[IncoercibleException] {
       for {
         _ <- "CREATE (level: Level { value: 3 })".query[Unit].execute(s)
         _ <- "CREATE (level: Level { value: -1 })".query[Unit].execute(s)
@@ -76,7 +76,7 @@ class RefinedSpec extends CleaningIntegrationSpec[Future] {
   }
 
   it should "fail if at least one wrapped value does not satisfy the refinement condition" in execute { s =>
-    recoverToSucceededIf[UncoercibleException] {
+    recoverToSucceededIf[IncoercibleException] {
       for {
         _ <- "CREATE (levels: Levels { values: [3, -1, 5] })".query[Unit].execute(s)
         levels <- "MATCH (levels: Levels) UNWIND levels.values AS level RETURN level".query[Option[Level]].list(s)
@@ -85,7 +85,7 @@ class RefinedSpec extends CleaningIntegrationSpec[Future] {
   }
 
   it should "fail if at least one value inside a case class does not satisfy the refinement condition" in execute { s =>
-    recoverToSucceededIf[UncoercibleException] {
+    recoverToSucceededIf[IncoercibleException] {
       for {
         _ <- "CREATE (user: User { name: \"???\", level: -1 })".query[Unit].execute(s)
         user <- "MATCH (user: User { name: \"???\" }) RETURN user".query[User].single(s)


### PR DESCRIPTION
This PR corrects a number of spelling issues in the project and makes no functional changes.

For example:
UncoercibleException -> IncoercibleException
CompabilityMappers -> CompatibilityMappers
commited -> committed

All tests pass.