### PR TITLE
Fixing type inference error with the cats.effect.IO implicit

### DIFF
--- a/cats-effect/src/main/scala/neotypes/cats/effect/package.scala
+++ b/cats-effect/src/main/scala/neotypes/cats/effect/package.scala
@@ -3,6 +3,6 @@ package cats
 
 package object effect {
   final object implicits extends CatsEffect {
-    implicit final val IOAsync: Async[_root_.cats.effect.IO] = catsAsync
+    implicit final val IOAsync: Async.Aux[_root_.cats.effect.IO, FResource[_root_.cats.effect.IO]#R] = catsAsync
   }
 }


### PR DESCRIPTION
I believe I added the issue when adding support to `2.13` and just noticed until today upgrading a personal project. Since this is just a bug fix and the bug was added in the `0.13.0` version, I suggest releasing a `0.13.1` version after merging this.