### PR TITLE
Making Session thread safe

### DIFF
--- a/akka-stream/src/test/scala/neotypes/akkastreams/AkkaStreamsSuite.scala
+++ b/akka-stream/src/test/scala/neotypes/akkastreams/AkkaStreamsSuite.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.scaladsl.Sink
 import neotypes.{FutureTestkit, Stream, StreamSuite, StreamTestkit}
 import neotypes.akkastreams.implicits._
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future, blocking}
 import scala.concurrent.duration.Duration
 
 /** Implementation of the Stream Teskit for akka streams. */
@@ -19,7 +19,7 @@ object AkkaStreamsTestkit extends StreamTestkit[AkkaStream, Future](FutureTestki
           Future {
             // Delaying the answer a little seems to fix:
             // https://github.com/neotypes/neotypes/issues/47
-            Thread.sleep(1000)
+            blocking(Thread.sleep(1000))
             result
           }
         }

--- a/cats-data/src/test/scala/neotypes/cats/data/CatsDataSpec.scala
+++ b/cats-data/src/test/scala/neotypes/cats/data/CatsDataSpec.scala
@@ -24,7 +24,7 @@ import scala.concurrent.Future
 final class CatsDataSpec extends CleaningIntegrationSpec[Future](FutureTestkit) {
   import CatsDataSpec._
 
-  it should "work with Chain" in execute { s =>
+  it should "work with Chain" in executeAsFuture { s =>
     val messages: Messages = Chain("a", "b")
 
     for {
@@ -37,7 +37,7 @@ final class CatsDataSpec extends CleaningIntegrationSpec[Future](FutureTestkit) 
     }
   }
 
-  it should "work with Const" in execute { s =>
+  it should "work with Const" in executeAsFuture { s =>
     val name: Name = Const("Balmung")
 
     for {
@@ -50,7 +50,7 @@ final class CatsDataSpec extends CleaningIntegrationSpec[Future](FutureTestkit) 
     }
   }
 
-  it should "work with NonEmptyChain" in execute { s =>
+  it should "work with NonEmptyChain" in executeAsFuture { s =>
     val errors: Errors = NonEmptyChain("a", "b")
 
     for {
@@ -63,7 +63,7 @@ final class CatsDataSpec extends CleaningIntegrationSpec[Future](FutureTestkit) 
     }
   }
 
-  it should "fail if retrieving an empty list as a NonEmptyChain" in execute { s =>
+  it should "fail if retrieving an empty list as a NonEmptyChain" in executeAsFuture { s =>
     recoverToSucceededIf[IncoercibleException] {
       for {
         _ <- "CREATE (stackTrace: StackTrace { line: 1, errors: [] })".query[Unit].execute(s)
@@ -72,7 +72,7 @@ final class CatsDataSpec extends CleaningIntegrationSpec[Future](FutureTestkit) 
     }
   }
 
-  it should "work with NonEmptyList" in execute { s =>
+  it should "work with NonEmptyList" in executeAsFuture { s =>
     val items: Items = NonEmptyList.of("a", "b")
 
     for {
@@ -85,7 +85,7 @@ final class CatsDataSpec extends CleaningIntegrationSpec[Future](FutureTestkit) 
     }
   }
 
-  it should "fail if retrieving an empty list as a NonEmptyList" in execute { s =>
+  it should "fail if retrieving an empty list as a NonEmptyList" in executeAsFuture { s =>
     recoverToSucceededIf[IncoercibleException] {
       for {
         _ <- "CREATE (player: Player { name: \"Luis\", items: [] })".query[Unit].execute(s)
@@ -94,7 +94,7 @@ final class CatsDataSpec extends CleaningIntegrationSpec[Future](FutureTestkit) 
     }
   }
 
-  it should "work with NonEmptyMap" in execute { s =>
+  it should "work with NonEmptyMap" in executeAsFuture { s =>
     val properties: Properties = NonEmptyMap.of("a" -> true, "b" -> false)
 
     for {
@@ -107,7 +107,7 @@ final class CatsDataSpec extends CleaningIntegrationSpec[Future](FutureTestkit) 
     }
   }
 
-  it should "fail if retrieving an empty map as a NonEmptyMap" in execute { s =>
+  it should "fail if retrieving an empty map as a NonEmptyMap" in executeAsFuture { s =>
     recoverToSucceededIf[IncoercibleException] {
       for {
         properties <- "RETURN {}".query[Properties].single(s)
@@ -115,7 +115,7 @@ final class CatsDataSpec extends CleaningIntegrationSpec[Future](FutureTestkit) 
     }
   }
 
-  it should "work with NonEmptySet" in execute { s =>
+  it should "work with NonEmptySet" in executeAsFuture { s =>
     val numbers: Numbers = NonEmptySet.of(1, 3, 5)
 
     for {
@@ -128,7 +128,7 @@ final class CatsDataSpec extends CleaningIntegrationSpec[Future](FutureTestkit) 
     }
   }
 
-  it should "fail if retrieving an empty list as a NonEmptySet" in execute { s =>
+  it should "fail if retrieving an empty list as a NonEmptySet" in executeAsFuture { s =>
     recoverToSucceededIf[IncoercibleException] {
       for {
         _ <- "CREATE (set: Set { name: \"favourites\", numbers: [] })".query[Unit].execute(s)
@@ -137,7 +137,7 @@ final class CatsDataSpec extends CleaningIntegrationSpec[Future](FutureTestkit) 
     }
   }
 
-  it should "work with NonEmptyVector" in execute { s =>
+  it should "work with NonEmptyVector" in executeAsFuture { s =>
     val groceries: Groceries = NonEmptyVector.of("a", "b")
 
     for {
@@ -150,7 +150,7 @@ final class CatsDataSpec extends CleaningIntegrationSpec[Future](FutureTestkit) 
     }
   }
 
-  it should "fail if retrieving an empty list as a NonEmptyVector" in execute { s =>
+  it should "fail if retrieving an empty list as a NonEmptyVector" in executeAsFuture { s =>
     recoverToSucceededIf[IncoercibleException] {
       for {
         _ <- "CREATE (purchase: Purchase { total: 12.5, groceries: [] })".query[Unit].execute(s)

--- a/cats-effect/src/main/scala/neotypes/cats/effect/CatsEffect.scala
+++ b/cats-effect/src/main/scala/neotypes/cats/effect/CatsEffect.scala
@@ -1,11 +1,12 @@
 package neotypes.cats.effect
 
-import cats.effect.{Async => CatsAsync, ExitCase, Resource}
+import cats.effect.{Concurrent, ExitCase, Resource}
+import cats.effect.concurrent.MVar
 
 trait CatsEffect {
   private[neotypes] final type FResource[F[_]] = { type R[A] = Resource[F, A] }
 
-  implicit final def catsAsync[F[_]](implicit F: CatsAsync[F]): neotypes.Async.Aux[F, FResource[F]#R] =
+  implicit final def catsAsync[F[_]](implicit F: Concurrent[F]): neotypes.Async.Aux[F, FResource[F]#R] =
     new neotypes.Async[F] {
       override final type R[A] = Resource[F, A]
 
@@ -29,13 +30,24 @@ trait CatsEffect {
       override final def flatMap[T, U](m: F[T])(f: T => F[U]): F[U] =
         F.flatMap(m)(f)
 
+      override def makeLock: F[Lock] =
+        F.map(MVar[F].empty[Unit]) { mvar =>
+          new Lock {
+            override final def acquire: F[Unit] =
+              mvar.put(())
+
+            override final def release: F[Unit] =
+              mvar.take
+          }
+        }
+
       override final def map[T, U](m: F[T])(f: T => U): F[U] =
         F.map(m)(f)
 
       override final def recoverWith[T, U >: T](m: F[T])(f: PartialFunction[Throwable, F[U]]): F[U] =
         F.recoverWith(F.widen[T, U](m))(f)
 
-      override final def resource[A](input: => A)(close: A => F[Unit]): Resource[F, A] =
-        Resource.make(F.delay(input))(close)
+      override final def resource[A](input: F[A])(close: A => F[Unit]): Resource[F, A] =
+        Resource.make(input)(close)
     }
 }

--- a/cats-effect/src/main/scala/neotypes/cats/effect/package.scala
+++ b/cats-effect/src/main/scala/neotypes/cats/effect/package.scala
@@ -1,8 +1,10 @@
 package neotypes
 package cats
 
+import _root_.cats.effect.{ContextShift, IO}
+
 package object effect {
   final object implicits extends CatsEffect {
-    implicit final val IOAsync: Async.Aux[_root_.cats.effect.IO, FResource[_root_.cats.effect.IO]#R] = catsAsync
+    implicit final def IOAsync(implicit cs: ContextShift[IO]): Async.Aux[IO, FResource[IO]#R] = catsAsync
   }
 }

--- a/cats-effect/src/test/scala/neotypes/cats/effect/CatsImplicitsSpec.scala
+++ b/cats-effect/src/test/scala/neotypes/cats/effect/CatsImplicitsSpec.scala
@@ -1,26 +1,27 @@
 package neotypes.cats.effect
 
 import cats.{Applicative, Monad}
-import cats.effect.{Async, IO, Resource}
+import cats.effect.{Concurrent, ContextShift, IO, Resource}
 import cats.effect.implicits._
 import cats.implicits._
 import neotypes.{BaseIntegrationSpec, Driver, Session}
 import neotypes.cats.effect.implicits._
 import neotypes.implicits.all._
 import org.neo4j.driver.exceptions.ClientException
+import org.testcontainers.shaded.okio.AsyncTimeout
 
 /** Ensures the neotypes implicits does not collide with the cats ones. */
-final class CatsImplicitsSpec extends BaseIntegrationSpec[IO](IOTestkit) {
+final class CatsImplicitsSpec extends BaseIntegrationSpec[IO](IOTestkit) { self =>
   it should "work with cats implicits and neotypes implicits" in {
     def test1[F[_]: Applicative]: F[Unit] = Applicative[F].unit
     def test2[F[_]: Monad]: F[Unit] = ().pure[F]
 
-    def makeSession[F[_]: Async]: Resource[F, Session[F]] =
+    def makeSession[F[_]: Concurrent]: Resource[F, Session[F]] =
       Resource
-        .make(Async[F].delay(new Driver[F](this.driver)))(_.close)
+        .make(Concurrent[F].delay(new Driver[F](this.driver)))(_.close)
         .flatMap(_.session)
 
-    def useSession[F[_]: Async]: F[String] = makeSession[F].use { s =>
+    def useSession[F[_]: Concurrent]: F[String] = makeSession[F].use { s =>
       (test1[F] *> test2[F]).flatMap { _ =>
         """match (p:Person {name: "Charlize Theron"}) return p.name"""
           .query[String]
@@ -28,6 +29,7 @@ final class CatsImplicitsSpec extends BaseIntegrationSpec[IO](IOTestkit) {
       }
     }
 
+    implicit val cs: ContextShift[IO] = IO.contextShift(self.executionContext)
     useSession[IO].unsafeToFuture().map { name =>
       assert(name == "Charlize Theron")
     }

--- a/cats-effect/src/test/scala/neotypes/cats/effect/IOSuite.scala
+++ b/cats-effect/src/test/scala/neotypes/cats/effect/IOSuite.scala
@@ -13,6 +13,9 @@ object IOTestkit extends EffectTestkit[IO] {
       implicit val cs: ContextShift[IO] =
         IO.contextShift(ec)
 
+      override final def fToT[T](io: IO[T]): T =
+        io.unsafeRunSync()
+
       override final def fToFuture[T](io: IO[T]): Future[T] =
         io.unsafeToFuture()
 

--- a/core/src/main/scala/neotypes/Async.scala
+++ b/core/src/main/scala/neotypes/Async.scala
@@ -8,32 +8,32 @@ import scala.util.{Failure, Success}
 
 @annotation.implicitNotFound("The effect type ${F} is not supported by neotypes")
 trait Async[F[_]] {
-  type R[A]
+  private[neotypes] type R[A]
 
-  trait Lock {
+  private[neotypes] trait Lock {
     def acquire: F[Unit]
     def release: F[Unit]
   }
 
-  def async[A](cb: (Either[Throwable, A] => Unit) => Unit): F[A]
+  private[neotypes] def async[A](cb: (Either[Throwable, A] => Unit) => Unit): F[A]
 
-  def delay[A](a: => A): F[A]
+  private[neotypes] def delay[A](a: => A): F[A]
 
-  def failed[A](e: Throwable): F[A]
+  private[neotypes] def failed[A](e: Throwable): F[A]
 
-  def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B]
+  private[neotypes] def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B]
 
-  def guarantee[A, B](fa: F[A])
-                     (f: A => F[B])
-                     (finalizer: (A, Option[Throwable]) => F[Unit]): F[B]
+  private[neotypes] def guarantee[A, B](fa: F[A])
+                                       (f: A => F[B])
+                                       (finalizer: (A, Option[Throwable]) => F[Unit]): F[B]
 
-  def makeLock: F[Lock]
+  private[neotypes] def makeLock: F[Lock]
 
-  def map[A, B](fa: F[A])(f: A => B): F[B]
+  private[neotypes] def map[A, B](fa: F[A])(f: A => B): F[B]
 
-  def recoverWith[A, B >: A](fa: F[A])(f: PartialFunction[Throwable, F[B]]): F[B]
+  private[neotypes] def recoverWith[A, B >: A](fa: F[A])(f: PartialFunction[Throwable, F[B]]): F[B]
 
-  def resource[A](input: F[A])(close: A => F[Unit]): R[A]
+  private[neotypes] def resource[A](input: F[A])(close: A => F[Unit]): R[A]
 }
 
 object Async {

--- a/core/src/main/scala/neotypes/Async.scala
+++ b/core/src/main/scala/neotypes/Async.scala
@@ -3,7 +3,7 @@ package neotypes
 import java.util.concurrent.ArrayBlockingQueue
 
 import scala.concurrent.{Await, ExecutionContext, Future, Promise, blocking}
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration._ // Provides the second extension method.
 import scala.util.{Failure, Success}
 
 @annotation.implicitNotFound("The effect type ${F} is not supported by neotypes")
@@ -93,6 +93,6 @@ object Async {
         fa.recoverWith(f)
 
       override final def resource[A](input: Future[A])(close: A => Future[Unit]): A =
-        Await.result(input, Duration.Inf)
+        Await.result(input, 1.second)
     }
 }

--- a/core/src/main/scala/neotypes/Async.scala
+++ b/core/src/main/scala/neotypes/Async.scala
@@ -1,11 +1,19 @@
 package neotypes
 
-import scala.concurrent.{ExecutionContext, Future, Promise}
+import java.util.concurrent.ArrayBlockingQueue
+
+import scala.concurrent.{Await, ExecutionContext, Future, Promise, blocking}
+import scala.concurrent.duration.Duration
 import scala.util.{Failure, Success}
 
 @annotation.implicitNotFound("The effect type ${F} is not supported by neotypes")
 trait Async[F[_]] {
   type R[A]
+
+  trait Lock {
+    def acquire: F[Unit]
+    def release: F[Unit]
+  }
 
   def async[A](cb: (Either[Throwable, A] => Unit) => Unit): F[A]
 
@@ -19,16 +27,17 @@ trait Async[F[_]] {
                      (f: A => F[B])
                      (finalizer: (A, Option[Throwable]) => F[Unit]): F[B]
 
+  def makeLock: F[Lock]
+
   def map[A, B](fa: F[A])(f: A => B): F[B]
 
   def recoverWith[A, B >: A](fa: F[A])(f: PartialFunction[Throwable, F[B]]): F[B]
 
-  def resource[A](input: => A)(close: A => F[Unit]): R[A]
+  def resource[A](input: F[A])(close: A => F[Unit]): R[A]
 }
 
 object Async {
   type Aux[F[_], _R[_]] = Async[F] { type R[A] = _R[A] }
-
   private[neotypes] type Id[A] = A
 
   implicit def futureAsync(implicit ec: ExecutionContext): Async.Aux[Future, Id] =
@@ -64,13 +73,26 @@ object Async {
           }
         }
 
+      override final def makeLock: Future[Lock] =
+        Future.successful {
+          val q = new ArrayBlockingQueue[Unit](1)
+
+          new Lock {
+            override final def acquire: Future[Unit] =
+              Future(blocking(q.put(())))
+
+            override final def release: Future[Unit] =
+              Future(blocking(q.take()))
+          }
+        }
+
       override final def map[A, B](fa: Future[A])(f: A => B): Future[B] =
         fa.map(f)
 
       override final def recoverWith[A, B >: A](fa: Future[A])(f: PartialFunction[Throwable, Future[B]]): Future[B] =
         fa.recoverWith(f)
 
-      override final def resource[A](input: => A)(close: A => Future[Unit]): A =
-        input
+      override final def resource[A](input: Future[A])(close: A => Future[Unit]): A =
+        Await.result(input, Duration.Inf)
     }
 }

--- a/core/src/main/scala/neotypes/DeferredQuery.scala
+++ b/core/src/main/scala/neotypes/DeferredQuery.scala
@@ -37,7 +37,7 @@ final case class DeferredQuery[T] private[neotypes] (query: String, params: Map[
     * @return An effectual value that will compute a List of T elements.
     */
   def list[F[_]](session: Session[F], config: NeoTransactionConfig = NeoTransactionConfig.empty)
-                (implicit F: Async[F], rm: ResultMapper[T]): F[List[T]] =
+                (implicit rm: ResultMapper[T]): F[List[T]] =
     session.transact(config)(tx => list(tx))
 
   /** Executes the query and returns a Map[K,V] of values.
@@ -60,7 +60,7 @@ final case class DeferredQuery[T] private[neotypes] (query: String, params: Map[
     * @return An effectual value that will compute a Map of key-value pairs.
     */
   def map[F[_], K, V](session: Session[F], config: NeoTransactionConfig = NeoTransactionConfig.empty)
-                     (implicit ev: T <:< (K, V), F: Async[F], rm: ResultMapper[(K, V)]): F[Map[K, V]] =
+                     (implicit ev: T <:< (K, V), rm: ResultMapper[(K, V)]): F[Map[K, V]] =
     session.transact(config)(tx => map(tx))
 
   /** Executes the query and returns a Set of values.
@@ -80,7 +80,7 @@ final case class DeferredQuery[T] private[neotypes] (query: String, params: Map[
     * @return An effectual value that will compute a Set of T elements.
     */
   def set[F[_]](session: Session[F], config: NeoTransactionConfig = NeoTransactionConfig.empty)
-               (implicit F: Async[F], rm: ResultMapper[T]): F[Set[T]] =
+               (implicit rm: ResultMapper[T]): F[Set[T]] =
     session.transact(config)(tx => set(tx))
 
   /** Executes the query and returns a Vector of values.
@@ -100,7 +100,7 @@ final case class DeferredQuery[T] private[neotypes] (query: String, params: Map[
     * @return An effectual value that will compute a Vector of T elements.
     */
   def vector[F[_]](session: Session[F], config: NeoTransactionConfig = NeoTransactionConfig.empty)
-                  (implicit F: Async[F], rm: ResultMapper[T]): F[Vector[T]] =
+                  (implicit rm: ResultMapper[T]): F[Vector[T]] =
     session.transact(config)(tx => vector(tx))
 
   /** Executes the query and returns the unique record in the result.
@@ -122,7 +122,7 @@ final case class DeferredQuery[T] private[neotypes] (query: String, params: Map[
     * @return An effectual value that will compute a single T element.
     */
   def single[F[_]](session: Session[F],config: NeoTransactionConfig = NeoTransactionConfig.empty)
-                  (implicit F: Async[F], rm: ResultMapper[T]): F[T] =
+                  (implicit rm: ResultMapper[T]): F[T] =
     session.transact(config)(tx => single(tx))
 
   /** Executes the query and ignores its output.
@@ -141,7 +141,7 @@ final case class DeferredQuery[T] private[neotypes] (query: String, params: Map[
     * @return An effectual value that will execute the query.
     */
   def execute[F[_]](session: Session[F], config: NeoTransactionConfig = NeoTransactionConfig.empty)
-                   (implicit F: Async[F], rm: ExecutionMapper[T]): F[T] =
+                   (implicit rm: ExecutionMapper[T]): F[T] =
     session.transact(config)(tx => execute(tx))
 
   /** Executes the query and returns a List of values.
@@ -161,7 +161,7 @@ final case class DeferredQuery[T] private[neotypes] (query: String, params: Map[
     * @return An effectual value that will compute a List of T elements.
     */
   def list[F[_]](tx: Transaction[F])
-                (implicit F: Async[F], rm: ResultMapper[T]): F[List[T]] =
+                (implicit rm: ResultMapper[T]): F[List[T]] =
     tx.list(query, params)
 
   /** Executes the query and returns a Map of values.
@@ -184,7 +184,7 @@ final case class DeferredQuery[T] private[neotypes] (query: String, params: Map[
     * @return An effectual value that will compute a Map of key-value pairs.
     */
   def map[F[_], K, V](tx: Transaction[F])
-                     (implicit ev: T <:< (K, V), F: Async[F], rm: ResultMapper[(K, V)]): F[Map[K, V]] = {
+                     (implicit ev: T <:< (K, V), rm: ResultMapper[(K, V)]): F[Map[K, V]] = {
     internal.utils.void(ev)
     tx.map(query, params)
   }
@@ -206,7 +206,7 @@ final case class DeferredQuery[T] private[neotypes] (query: String, params: Map[
     * @return An effectual value that will compute a Set of T elements.
     */
   def set[F[_]](tx: Transaction[F])
-               (implicit F: Async[F], rm: ResultMapper[T]): F[Set[T]] =
+               (implicit rm: ResultMapper[T]): F[Set[T]] =
     tx.set(query, params)
 
   /** Executes the query and returns a Vector of values.
@@ -226,7 +226,7 @@ final case class DeferredQuery[T] private[neotypes] (query: String, params: Map[
     * @return An effectual value that will compute a Vector of T elements.
     */
   def vector[F[_]](tx: Transaction[F])
-                  (implicit F: Async[F], rm: ResultMapper[T]): F[Vector[T]] =
+                  (implicit rm: ResultMapper[T]): F[Vector[T]] =
     tx.vector(query, params)
 
   /** Executes the query and returns the unique record in the result.
@@ -248,7 +248,7 @@ final case class DeferredQuery[T] private[neotypes] (query: String, params: Map[
     * @return An effectual value that will compute a single T element.
     */
   def single[F[_]](tx: Transaction[F])
-                  (implicit F: Async[F], rm: ResultMapper[T]): F[T] =
+                  (implicit rm: ResultMapper[T]): F[T] =
     tx.single(query, params)
 
   /** Executes the query and ignores its output.
@@ -267,7 +267,7 @@ final case class DeferredQuery[T] private[neotypes] (query: String, params: Map[
     * @return An effectual value that will execute the query.
     */
   def execute[F[_]](tx: Transaction[F])
-                   (implicit F: Async[F], rm: ExecutionMapper[T]): F[T] =
+                   (implicit rm: ExecutionMapper[T]): F[T] =
     tx.execute(query, params)
 
   /** Executes the query and returns a custom collection of values.
@@ -312,13 +312,13 @@ final case class DeferredQuery[T] private[neotypes] (query: String, params: Map[
 private[neotypes] object DeferredQuery {
   private[neotypes] final class CollectAsPartiallyApplied[T, C](private val factoryAndDq: (Factory[T, C], DeferredQuery[T])) extends AnyVal {
     def apply[F[_]](session: Session[F], config: NeoTransactionConfig = NeoTransactionConfig.empty)
-                   (implicit F: Async[F], rm: ResultMapper[T]): F[C] = {
+                   (implicit rm: ResultMapper[T]): F[C] = {
       val (factory, dq) = factoryAndDq
       session.transact(config)(tx => tx.collectAs(factory)(dq.query, dq.params))
     }
 
     def apply[F[_]](tx: Transaction[F])
-                   (implicit F: Async[F], rm: ResultMapper[T]): F[C] = {
+                   (implicit rm: ResultMapper[T]): F[C] = {
       val (factory, dq) = factoryAndDq
       tx.collectAs(factory)(dq.query, dq.params)
     }
@@ -326,16 +326,15 @@ private[neotypes] object DeferredQuery {
 
   private[neotypes] final class StreamPartiallyApplied[S[_], T](private val dq: DeferredQuery[T]) extends AnyVal {
     def apply[F[_]](session: Session[F], config: NeoTransactionConfig = NeoTransactionConfig.empty)
-                   (implicit F: Async[F], rm: ResultMapper[T], S: Stream.Aux[S, F]): S[T] =
+                   (implicit rm: ResultMapper[T], F: Async[F], S: Stream.Aux[S, F]): S[T] =
       S.fToS(
-        session.transaction(config).flatMap { tx =>
-          F.delay(
-            S.onComplete(tx.stream(dq.query, dq.params))(tx.rollback)
-          )
+        session.transaction(config).map { tx =>
+          S.onComplete(tx.stream(dq.query, dq.params))(tx.rollback)
         }
       )
 
-    def apply[F[_]](tx: Transaction[F])(implicit F: Async[F], rm: ResultMapper[T], S: Stream.Aux[S, F]): S[T] =
+    def apply[F[_]](tx: Transaction[F])
+                   (implicit rm: ResultMapper[T], S: Stream.Aux[S, F]): S[T] =
       tx.stream(dq.query, dq.params)
   }
 }

--- a/core/src/main/scala/neotypes/Driver.scala
+++ b/core/src/main/scala/neotypes/Driver.scala
@@ -16,7 +16,7 @@ import org.neo4j.driver.{AccessMode, Driver => NeoDriver, SessionConfig}
   *
   * @define futinfo When your effect type is scala.Future there is no concept of Resource. For more information see <a href = https://neotypes.github.io/neotypes/docs/alternative_effects.html>alternative effects</a>
   */
-final class Driver[F[_]] private[neotypes] (private val driver: NeoDriver) extends AnyVal {
+final class Driver[F[_]] private[neotypes] (private val driver: NeoDriver) {
 
   /** Acquire a session to the database with the default config.
     * @note $futinfo
@@ -41,8 +41,9 @@ final class Driver[F[_]] private[neotypes] (private val driver: NeoDriver) exten
                    (implicit F: Async.Aux[F, R]): R[Session[F]] =
     F.resource(createSession(config))(session => session.close)
 
-  private[this] def createSession(config: SessionConfig): Session[F] =
-    new Session(driver.asyncSession(config))
+  private[this] def createSession(config: SessionConfig)
+                                 (implicit F: Async[F]): Session[F] =
+    Session(driver.asyncSession(config))
 
   /** Apply a unit of work to a read session
     *

--- a/core/src/main/scala/neotypes/GraphDatabase.scala
+++ b/core/src/main/scala/neotypes/GraphDatabase.scala
@@ -86,6 +86,6 @@ object GraphDatabase {
 
     private def create[R[_]](neoDriver: => NDriver)
                             (implicit F: Async.Aux[F, R]): R[Driver[F]] =
-      F.resource(new Driver[F](neoDriver))(driver => driver.close)
+      F.resource(F.delay(new Driver[F](neoDriver)))(driver => driver.close)
   }
 }

--- a/core/src/main/scala/neotypes/Session.scala
+++ b/core/src/main/scala/neotypes/Session.scala
@@ -6,28 +6,43 @@ import internal.syntax.stage._
 import org.neo4j.driver.{TransactionConfig => NeoTransactionConfig}
 import org.neo4j.driver.async.{AsyncSession => NeoAsyncSession}
 
-final class Session[F[_]] private[neotypes] (private val session: NeoAsyncSession) {
-  def transaction(implicit F: Async[F]): F[Transaction[F]] =
-    transaction(NeoTransactionConfig.empty)
+sealed trait Session[F[_]] {
+  def transaction: F[Transaction[F]]
 
-  def transaction(config: NeoTransactionConfig)(implicit F: Async[F]): F[Transaction[F]] =
-    F.async { cb =>
-      session.beginTransactionAsync(config).accept(cb) { tx =>
-        Right(new Transaction(tx))
+  def transaction(config: NeoTransactionConfig): F[Transaction[F]]
+
+  def transact[T](txF: Transaction[F] => F[T]): F[T]
+
+  def transact[T](config: NeoTransactionConfig)(txF: Transaction[F] => F[T]): F[T]
+
+  def close: F[Unit]
+}
+
+object Session {
+  private[neotypes] def apply[F[_]](session: NeoAsyncSession)
+                                   (implicit F: Async[F]): Session[F] = new Session[F] {
+    override final def transaction: F[Transaction[F]] =
+      transaction(NeoTransactionConfig.empty)
+
+    override final def transaction(config: NeoTransactionConfig): F[Transaction[F]] =
+      F.async { cb =>
+        session.beginTransactionAsync(config).accept(cb) { tx =>
+          Right(Transaction(tx))
+        }
       }
-    }
 
-  def transact[T](txF: Transaction[F] => F[T])(implicit F: Async[F]): F[T] =
-    transact(NeoTransactionConfig.empty)(txF)
+    override final def transact[T](txF: Transaction[F] => F[T]): F[T] =
+      transact(NeoTransactionConfig.empty)(txF)
 
-  def transact[T](config: NeoTransactionConfig)(txF: Transaction[F] => F[T])(implicit F: Async[F]): F[T] =
-    transaction(config).guarantee(txF) {
-      case (tx, None)    => tx.commit
-      case (tx, Some(_)) => tx.rollback
-    }
+    override final def transact[T](config: NeoTransactionConfig)(txF: Transaction[F] => F[T]): F[T] =
+      transaction(config).guarantee(txF) {
+        case (tx, None)    => tx.commit
+        case (tx, Some(_)) => tx.rollback
+      }
 
-  def close(implicit F: Async[F]): F[Unit] =
-    F.async { cb =>
-      session.closeAsync().acceptVoid(cb)
-    }
+    override final def close: F[Unit] =
+      F.async { cb =>
+        session.closeAsync().acceptVoid(cb)
+      }
+  }
 }

--- a/core/src/main/scala/neotypes/Session.scala
+++ b/core/src/main/scala/neotypes/Session.scala
@@ -27,9 +27,11 @@ object Session {
       transaction(NeoTransactionConfig.empty)
 
     override final def transaction(config: NeoTransactionConfig): F[Transaction[F]] =
-      lock.acquire >> F.async { cb =>
-        session.beginTransactionAsync(config).accept(cb) { tx =>
-          Right(Transaction(F, tx)(lock))
+      lock.acquire.flatMap { _ =>
+        F.async { cb =>
+          session.beginTransactionAsync(config).accept(cb) { tx =>
+            Right(Transaction(F, tx)(lock))
+          }
         }
       }
 

--- a/core/src/main/scala/neotypes/Transaction.scala
+++ b/core/src/main/scala/neotypes/Transaction.scala
@@ -140,11 +140,15 @@ object Transaction {
     override final def commit: F[Unit] =
       F.async[Unit] { cb =>
         transaction.commitAsync().acceptVoid(cb)
-      } >> lock.release
+      } flatMap { _=>
+        lock.release
+      }
 
     override final def rollback: F[Unit] =
       F.async[Unit] { cb =>
         transaction.rollbackAsync().acceptVoid(cb)
-      } >> lock.release
+      } flatMap { _ =>
+        lock.release
+      }
   }
 }

--- a/core/src/main/scala/neotypes/Transaction.scala
+++ b/core/src/main/scala/neotypes/Transaction.scala
@@ -14,105 +14,134 @@ import org.neo4j.driver.exceptions.NoSuchRecordException
 import scala.collection.compat._
 import scala.jdk.CollectionConverters._
 
-final class Transaction[F[_]] private[neotypes] (private val transaction: NeoAsyncTransaction) {
-  import Transaction._
-
+sealed trait Transaction[F[_]] {
   def execute[T](query: String, params: Map[String, QueryParam] = Map.empty)
-                (implicit F: Async[F], executionMapper: ExecutionMapper[T]): F[T] =
-    F.async { cb =>
-      transaction
-        .runAsync(query, QueryParam.toJavaMap(params))
-        .thenCompose(_.consumeAsync())
-        .accept(cb)(executionMapper.to)
-    }
+                (implicit executionMapper: ExecutionMapper[T]): F[T]
 
   def collectAs[C, T](factory: Factory[T, C])
                      (query: String, params: Map[String, QueryParam] = Map.empty)
-                     (implicit F: Async[F], resultMapper: ResultMapper[T]): F[C] =
-    collectAsImpl(this.transaction)(query, params)(traverseAs(factory))
+                     (implicit resultMapper: ResultMapper[T]): F[C]
 
   def list[T](query: String, params: Map[String, QueryParam] = Map.empty)
-             (implicit F: Async[F], resultMapper: ResultMapper[T]): F[List[T]] =
-    collectAsImpl(this.transaction)(query, params)(traverseAsList[Record, T])
+             (implicit resultMapper: ResultMapper[T]): F[List[T]]
 
   def map[K, V](query: String, params: Map[String, QueryParam] = Map.empty)
-               (implicit F: Async[F], resultMapper: ResultMapper[(K, V)]): F[Map[K, V]] =
-    collectAsImpl(this.transaction)(query, params)(traverseAsMap[Record, K, V])
+               (implicit resultMapper: ResultMapper[(K, V)]): F[Map[K, V]]
 
   def set[T](query: String, params: Map[String, QueryParam] = Map.empty)
-            (implicit F: Async[F], resultMapper: ResultMapper[T]): F[Set[T]] =
-    collectAsImpl(this.transaction)(query, params)(traverseAsSet[Record, T])
+            (implicit resultMapper: ResultMapper[T]): F[Set[T]]
 
   def vector[T](query: String, params: Map[String, QueryParam] = Map.empty)
-               (implicit F: Async[F], resultMapper: ResultMapper[T]): F[Vector[T]] =
-    collectAsImpl(this.transaction)(query, params)(traverseAsVector[Record, T])
+               (implicit resultMapper: ResultMapper[T]): F[Vector[T]]
 
   def single[T](query: String, params: Map[String, QueryParam] = Map.empty)
-               (implicit F: Async[F], resultMapper: ResultMapper[T]): F[T] =
-    F.async { cb =>
-      transaction
-        .runAsync(query, QueryParam.toJavaMap(params))
-        .thenCompose(_.singleAsync())
-        .acceptExceptionally(cb) { record =>
-          resultMapper.to(recordToList(record), None)
-        } {
-          case _: NoSuchRecordException => resultMapper.to(List.empty, None)
-        }
-    }
+               (implicit resultMapper: ResultMapper[T]): F[T]
 
-  def stream[T: ResultMapper, S[_]](query: String, params: Map[String, QueryParam] = Map.empty)
-                                   (implicit F: Async[F], S: Stream.Aux[S, F]): S[T] =
-    S.fToS(
-      F.async { cb =>
-        transaction
-          .runAsync(query, QueryParam.toJavaMap(params))
-          .accept(cb) { statementResultCursor =>
-            Right(S.init(() => nextAsyncToF(statementResultCursor.nextAsync())))
-          }
-      }
-    )
+  def stream[T, S[_]](query: String, params: Map[String, QueryParam] = Map.empty)
+                     (implicit S: Stream.Aux[S, F], resultMapper: ResultMapper[T]): S[T]
 
-  def commit(implicit F: Async[F]): F[Unit] =
-    F.async { cb =>
-      transaction.commitAsync().acceptVoid(cb)
-    }
+  def commit: F[Unit]
 
-  def rollback(implicit F: Async[F]): F[Unit] =
-    F.async { cb =>
-      transaction.rollbackAsync().acceptVoid(cb)
-    }
+  def rollback: F[Unit]
 }
 
 object Transaction {
-  private def recordToList(record: Record): List[(String, Value)] =
-    record.fields.asScala.iterator.map(p => p.key -> p.value).toList
+  private[neotypes] def apply[F[_]](transaction: NeoAsyncTransaction)
+                                   (implicit F: Async[F]): Transaction[F] = new Transaction[F] {
+    private def recordToList(record: Record): List[(String, Value)] =
+      record.fields.asScala.iterator.map(p => p.key -> p.value).toList
 
-  private def nextAsyncToF[F[_], T](cs: CompletionStage[Record])
-                                   (implicit F: Async[F], resultMapper: ResultMapper[T]): F[Option[T]] =
-    F.async { cb =>
-      cs.accept(cb) { r =>
-        Option(r) match {
-          case None =>
-            Right(None)
-
-          case Some(record) =>
-            resultMapper.to(recordToList(record), None).map(r => Option(r))
-        }
+    private def collectAsImpl[T, C](transaction: NeoAsyncTransaction, query: String, params: Map[String, QueryParam])
+                                   (traverseFun: Iterator[Record] => (Record => Either[Throwable, T]) => Either[Throwable, C])
+                                   (implicit resultMapper: ResultMapper[T]): F[C] =
+      F.async { cb =>
+        transaction
+          .runAsync(query, QueryParam.toJavaMap(params))
+          .thenCompose(_.listAsync())
+          .accept(cb) { records =>
+            traverseFun(records.asScala.iterator) { record =>
+              resultMapper.to(recordToList(record), None)
+            }
+          }
       }
-    }
 
-  private def collectAsImpl[F[_], T, C](transaction: NeoAsyncTransaction)
-                                       (query: String, params: Map[String, QueryParam])
-                                       (traverseFun: Iterator[Record] => (Record => Either[Throwable, T]) => Either[Throwable, C])
-                                       (implicit F: Async[F], resultMapper: ResultMapper[T]): F[C] =
-    F.async { cb =>
-      transaction
-        .runAsync(query, QueryParam.toJavaMap(params))
-        .thenCompose(_.listAsync())
-        .accept(cb) { records =>
-          traverseFun(records.asScala.iterator) { record =>
+    override final def execute[T](query: String, params: Map[String,QueryParam])
+                                 (implicit executionMapper: mappers.ExecutionMapper[T]): F[T] =
+      F.async { cb =>
+        transaction
+          .runAsync(query, QueryParam.toJavaMap(params))
+          .thenCompose(_.consumeAsync())
+          .accept(cb)(executionMapper.to)
+      }
+
+    override final def collectAs[C, T](factory: Factory[T,C])
+                                      (query: String, params: Map[String,QueryParam])
+                                      (implicit resultMapper: ResultMapper[T]): F[C] =
+      collectAsImpl(transaction, query, params)(traverseAs(factory))
+
+    override final def list[T](query: String, params: Map[String,QueryParam])
+                              (implicit resultMapper: ResultMapper[T]): F[List[T]] =
+      collectAsImpl(transaction, query, params)(traverseAsList[Record, T])
+
+    override final def map[K, V](query: String, params: Map[String,QueryParam])
+                                (implicit resultMapper: ResultMapper[(K, V)]): F[Map[K,V]] =
+      collectAsImpl(transaction, query, params)(traverseAsMap[Record, K, V])
+
+    override final def set[T](query: String, params: Map[String,QueryParam])
+                             (implicit resultMapper: ResultMapper[T]): F[Set[T]] =
+      collectAsImpl(transaction, query, params)(traverseAsSet[Record, T])
+
+    override final def vector[T](query: String, params: Map[String,QueryParam])
+                                (implicit resultMapper: ResultMapper[T]): F[Vector[T]] =
+      collectAsImpl(transaction, query, params)(traverseAsVector[Record, T])
+
+    override final def single[T](query: String, params: Map[String,QueryParam])
+                                (implicit resultMapper: ResultMapper[T]): F[T] =
+      F.async { cb =>
+        transaction
+          .runAsync(query, QueryParam.toJavaMap(params))
+          .thenCompose(_.singleAsync())
+          .acceptExceptionally(cb) { record =>
             resultMapper.to(recordToList(record), None)
+          } {
+            case _: NoSuchRecordException => resultMapper.to(List.empty, None)
+          }
+      }
+
+    private def nextAsyncToF[T](cs: CompletionStage[Record])
+                               (implicit resultMapper: ResultMapper[T]): F[Option[T]] =
+      F.async { cb =>
+        cs.accept(cb) { r =>
+          Option(r) match {
+            case None =>
+              Right(None)
+
+            case Some(record) =>
+              resultMapper.to(recordToList(record), None).map(r => Option(r))
           }
         }
-    }
+      }
+
+    override final def stream[T, S[_]](query: String, params: Map[String,QueryParam])
+                                      (implicit S: Stream.Aux[S,F], resultMapper: ResultMapper[T]): S[T] =
+      S.fToS(
+        F.async { cb =>
+          transaction
+            .runAsync(query, QueryParam.toJavaMap(params))
+            .accept(cb) { statementResultCursor =>
+              Right(S.init(() => nextAsyncToF(statementResultCursor.nextAsync())))
+            }
+        }
+      )
+
+    override final def commit: F[Unit] =
+      F.async { cb =>
+        transaction.commitAsync().acceptVoid(cb)
+      }
+
+    override final def rollback: F[Unit] =
+      F.async { cb =>
+        transaction.rollbackAsync().acceptVoid(cb)
+      }
+  }
 }

--- a/core/src/main/scala/neotypes/Transaction.scala
+++ b/core/src/main/scala/neotypes/Transaction.scala
@@ -140,14 +140,14 @@ object Transaction {
     override final def commit: F[Unit] =
       F.async[Unit] { cb =>
         transaction.commitAsync().acceptVoid(cb)
-      } flatMap { _=>
+      } guarantee { _ =>
         lock.release
       }
 
     override final def rollback: F[Unit] =
       F.async[Unit] { cb =>
         transaction.rollbackAsync().acceptVoid(cb)
-      } flatMap { _ =>
+      } guarantee { _ =>
         lock.release
       }
   }

--- a/core/src/main/scala/neotypes/internal/syntax/async.scala
+++ b/core/src/main/scala/neotypes/internal/syntax/async.scala
@@ -9,6 +9,9 @@ private[neotypes] object async {
     def flatMap[B](f: A => F[B])(implicit F: Async[F]): F[B] =
       F.flatMap(fa)(f)
 
+    def >>[B](fb: F[B])(implicit F: Async[F]): F[B] =
+      F.flatMap(fa)(_ => fb)
+
     def guarantee[B](f: A => F[B])(finalizer: (A, Option[Throwable]) => F[Unit])(implicit F: Async[F]): F[B] =
       F.guarantee(fa)(f)(finalizer)
 

--- a/core/src/main/scala/neotypes/internal/syntax/async.scala
+++ b/core/src/main/scala/neotypes/internal/syntax/async.scala
@@ -9,9 +9,6 @@ private[neotypes] object async {
     def flatMap[B](f: A => F[B])(implicit F: Async[F]): F[B] =
       F.flatMap(fa)(f)
 
-    def >>[B](fb: F[B])(implicit F: Async[F]): F[B] =
-      F.flatMap(fa)(_ => fb)
-
     def guarantee[B](f: A => F[B])(finalizer: (A, Option[Throwable]) => F[Unit])(implicit F: Async[F]): F[B] =
       F.guarantee(fa)(f)(finalizer)
 

--- a/core/src/main/scala/neotypes/internal/syntax/async.scala
+++ b/core/src/main/scala/neotypes/internal/syntax/async.scala
@@ -12,6 +12,11 @@ private[neotypes] object async {
     def guarantee[B](f: A => F[B])(finalizer: (A, Option[Throwable]) => F[Unit])(implicit F: Async[F]): F[B] =
       F.guarantee(fa)(f)(finalizer)
 
+    def guarantee(finalizer: Option[Throwable] => F[Unit])(implicit F: Async[F]): F[A] =
+      F.guarantee(F.delay(()))(_ => fa) {
+        case (_, ex) => finalizer(ex)
+      }
+
     def recover[B >: A](f: PartialFunction[Throwable, B])(implicit F: Async[F]): F[B] =
       F.recoverWith[A, B](fa)(f.andThen(b => F.delay(b)))
 

--- a/core/src/test/scala/neotypes/BaseIntegrationSpec.scala
+++ b/core/src/test/scala/neotypes/BaseIntegrationSpec.scala
@@ -29,7 +29,7 @@ abstract class BaseIntegrationSpec[F[_]](testkit: EffectTestkit[F]) extends Base
     driver.session()
 
   private lazy final val neotypesSession =
-    new Session[F](driver.asyncSession())
+    Session[F](driver.asyncSession())
 
   private final def runQuery(query: String): Unit = {
     neo4jSession.writeTransaction(

--- a/core/src/test/scala/neotypes/BaseIntegrationSpec.scala
+++ b/core/src/test/scala/neotypes/BaseIntegrationSpec.scala
@@ -28,7 +28,7 @@ abstract class BaseIntegrationSpec[F[_]](testkit: EffectTestkit[F]) extends Base
     driver.session()
 
   private lazy final val neotypesSession =
-    Session[F](driver.asyncSession())
+    Session[F](F, driver.asyncSession())(fToT(F.makeLock))
 
   private final def runQuery(query: String): Unit = {
     neo4jSession.writeTransaction(
@@ -53,11 +53,8 @@ abstract class BaseIntegrationSpec[F[_]](testkit: EffectTestkit[F]) extends Base
     runQuery("MATCH (n) DETACH DELETE n")
   }
 
-  protected final def execute[T](work: Session[F] => F[T])(implicit F: Async[F]): F[T] =
-    work(neotypesSession)
-
   protected final def executeAsFuture[T](work: Session[F] => F[T]): Future[T] =
-    fToFuture(execute(work))
+    fToFuture(work(neotypesSession))
 }
 
 object BaseIntegrationSpec {

--- a/core/src/test/scala/neotypes/ConcurrentSessionSpec.scala
+++ b/core/src/test/scala/neotypes/ConcurrentSessionSpec.scala
@@ -1,24 +1,29 @@
 package neotypes
 
+import neotypes.internal.syntax.async._
 import neotypes.implicits.mappers.all._
 import neotypes.implicits.syntax.cypher._
 import org.neo4j.driver.exceptions.ClientException
+import org.scalatest.matchers.should.Matchers
+import scala.concurrent.ExecutionContext
 
 /** Base class for testing the concurrent use of a session. */
-final class ConcurrentSessionSpec[F[_]](testkit: EffectTestkit[F]) extends BaseIntegrationSpec[F](testkit) {
+final class ConcurrentSessionSpec[F[_]](testkit: EffectTestkit[F]) extends BaseIntegrationSpec[F](testkit) with Matchers {
   behavior of s"Concurrent use of Session[${effectName}]"
+
+  // Use the global ec to ensure the tasks run concurrently.
+  override implicit final def executionContext: ExecutionContext = ExecutionContext.global
 
   it should "work and not throw an exception when a single session is used concurrently" in {
     executeAsFuture { s =>
-      def query(name: String): DeferredQuery[Unit] =
-        c"CREATE (p: PERSON { name: ${name} })".query[Unit]
+      def query(name: String): F[Unit] =
+        c"CREATE (p: PERSON { name: ${name} })".query[Unit].execute(s)
 
-      runConcurrently(
-        query(name = "name1").execute(s),
-        query(name = "name2").execute(s)
-      )
-    } map { _ =>
-      succeed
+      runConcurrently(query(name = "name1"), query(name = "name2")).flatMap { _ =>
+        c"MATCH (p: PERSON) RETURN p.name".query[String].list(s)
+      }
+    } map { result =>
+      result should contain theSameElementsAs List("name1", "name2")
     }
   }
 

--- a/core/src/test/scala/neotypes/ConcurrentSessionSpec.scala
+++ b/core/src/test/scala/neotypes/ConcurrentSessionSpec.scala
@@ -11,8 +11,11 @@ import scala.concurrent.ExecutionContext
 final class ConcurrentSessionSpec[F[_]](testkit: EffectTestkit[F]) extends BaseIntegrationSpec[F](testkit) with Matchers {
   behavior of s"Concurrent use of Session[${effectName}]"
 
-  // Use the global ec to ensure the tasks run concurrently.
-  override implicit final def executionContext: ExecutionContext = ExecutionContext.global
+  // Use a custom ec to ensure the tasks run concurrently.
+  override implicit final def executionContext: ExecutionContext =
+    ExecutionContext.fromExecutorService(
+      java.util.concurrent.Executors.newFixedThreadPool(2)
+    )
 
   it should "work and not throw an exception when a single session is used concurrently" in {
     executeAsFuture { s =>

--- a/core/src/test/scala/neotypes/ConcurrentSessionSpec.scala
+++ b/core/src/test/scala/neotypes/ConcurrentSessionSpec.scala
@@ -8,17 +8,17 @@ import org.neo4j.driver.exceptions.ClientException
 final class ConcurrentSessionSpec[F[_]](testkit: EffectTestkit[F]) extends BaseIntegrationSpec[F](testkit) {
   behavior of s"Concurrent use of Session[${effectName}]"
 
-  it should "throw a client exception when a single session is used concurrently" in {
-    recoverToSucceededIf[ClientException] {
-      executeAsFuture { s =>
-        def query(name: String): DeferredQuery[Unit] =
-          c"CREATE (p: PERSON { name: ${name} })".query[Unit]
+  it should "work and not throw an exception when a single session is used concurrently" in {
+    executeAsFuture { s =>
+      def query(name: String): DeferredQuery[Unit] =
+        c"CREATE (p: PERSON { name: ${name} })".query[Unit]
 
-        runConcurrently(
-          query(name = "name1").execute(s),
-          query(name = "name2").execute(s)
-        )
-      }
+      runConcurrently(
+        query(name = "name1").execute(s),
+        query(name = "name2").execute(s)
+      )
+    } map { _ =>
+      succeed
     }
   }
 

--- a/core/src/test/scala/neotypes/EffectSuite.scala
+++ b/core/src/test/scala/neotypes/EffectSuite.scala
@@ -10,6 +10,7 @@ abstract class EffectTestkit[F[_]](implicit ct: ClassTag[F[_]]) {
   final val effectName: String = ct.runtimeClass.getCanonicalName
 
   trait Behaviour {
+    def fToT[T](f: F[T]): T
     def fToFuture[T](f: F[T]): Future[T]
     def runConcurrently(a: F[Unit], b: F[Unit]): F[Unit]
     def asyncInstance: Async[F]
@@ -25,6 +26,9 @@ abstract class BaseEffectSpec[F[_]](testkit: EffectTestkit[F]) extends AsyncTest
 
   private final val behaviour: testkit.Behaviour =
     testkit.createBehaviour(self.executionContext)
+
+  protected final def fToT[T](f: F[T]): T =
+    behaviour.fToT(f)
 
   protected final def fToFuture[T](f: F[T]): Future[T] =
     behaviour.fToFuture(f)

--- a/core/src/test/scala/neotypes/FutureSuite.scala
+++ b/core/src/test/scala/neotypes/FutureSuite.scala
@@ -1,11 +1,15 @@
 package neotypes
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration.Duration
 
 /** Implementation of the Effect Teskit for scala Future. */
 object FutureTestkit extends EffectTestkit[Future] {
   override def createBehaviour(implicit ec: ExecutionContext): Behaviour =
     new Behaviour {
+      override final def fToT[T](future: Future[T]): T =
+        Await.result(future, Duration.Inf)
+
       override final def fToFuture[T](future: Future[T]): Future[T] =
         future
 

--- a/core/src/test/scala/neotypes/StreamIntegrationSpec.scala
+++ b/core/src/test/scala/neotypes/StreamIntegrationSpec.scala
@@ -3,12 +3,12 @@ package neotypes
 import neotypes.implicits.mappers.all._
 import neotypes.implicits.syntax.string._
 import org.neo4j.driver.exceptions.ClientException
-import org.scalatest.compatible.Assertion
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 
 /** Base class for testing the basic behavoir of Stream[S, F] instances. */
-final class StreamIntegrationSpec[S[_], F[_]](testkit: StreamTestkit[S, F]) extends BaseStreamSpec(testkit) {
+final class StreamIntegrationSpec[S[_], F[_]](testkit: StreamTestkit[S, F]) extends BaseStreamSpec(testkit) with Matchers {
   behavior of s"Stream[${streamName}, ${effectName}]"
 
   it should s"execute a streaming query" in {
@@ -17,7 +17,7 @@ final class StreamIntegrationSpec[S[_], F[_]](testkit: StreamTestkit[S, F]) exte
         .query[Int]
         .stream(s)
     } map { names =>
-      assert(names == (0 to 10).toList)
+      names should contain theSameElementsAs (0 to 10)
     }
   }
 

--- a/core/src/test/scala/neotypes/StreamSuite.scala
+++ b/core/src/test/scala/neotypes/StreamSuite.scala
@@ -25,7 +25,7 @@ abstract class BaseStreamSpec[S[_], F[_]](testkit: StreamTestkit[S, F]) extends 
     testkit.createBehaviour(self.executionContext)
 
   protected final def executeAsFutureList[T](work: Session[F] => S[T]): Future[List[T]] =
-    this.fToFuture(this.execute(work andThen behaviour.streamToFList))
+    this.executeAsFuture(work andThen behaviour.streamToFList)
 
   protected implicit final val S: Stream.Aux[S, F] =
     behaviour.streamInstance

--- a/monix/src/test/scala/neotypes/monix/MonixTaskSuite.scala
+++ b/monix/src/test/scala/neotypes/monix/MonixTaskSuite.scala
@@ -13,6 +13,9 @@ object MonixTaskTestkit extends EffectTestkit[Task] {
       implicit val scheduler: Scheduler =
         Scheduler(ec)
 
+      override final def fToT[T](task: Task[T]): T =
+        task.runSyncUnsafe()
+
       override final def fToFuture[T](task: Task[T]): Future[T] =
         task.runToFuture
 

--- a/refined/src/test/scala/neotypes/refined/RefinedSpec.scala
+++ b/refined/src/test/scala/neotypes/refined/RefinedSpec.scala
@@ -17,7 +17,7 @@ import scala.concurrent.Future
 final class RefinedSpec extends CleaningIntegrationSpec[Future](FutureTestkit) {
   import RefinedSpec.{Level, User}
 
-  it should "insert and retrieve one refined value" in execute { s =>
+  it should "insert and retrieve one refined value" in executeAsFuture { s =>
     val L1: Level = 1
 
     for {
@@ -26,7 +26,7 @@ final class RefinedSpec extends CleaningIntegrationSpec[Future](FutureTestkit) {
     } yield assert(level == L1)
   }
 
-  it should "insert and retrieve multiple refined values" in execute { s =>
+  it should "insert and retrieve multiple refined values" in executeAsFuture { s =>
     val L1: Level = 1
     val L2: Level = 2
 
@@ -37,7 +37,7 @@ final class RefinedSpec extends CleaningIntegrationSpec[Future](FutureTestkit) {
     } yield assert(levels == List(L1, L2))
   }
 
-  it should "insert and retrieve wrapped refined values" in execute { s =>
+  it should "insert and retrieve wrapped refined values" in executeAsFuture { s =>
     val L1: Level = 1
     val L2: Level = 2
     val levels = List(Option(L1), Option(L2))
@@ -48,14 +48,14 @@ final class RefinedSpec extends CleaningIntegrationSpec[Future](FutureTestkit) {
     } yield assert(levels == levels)
   }
 
-  it should "retrieve refined values inside a case class" in execute { s =>
+  it should "retrieve refined values inside a case class" in executeAsFuture { s =>
     for {
       _ <- "CREATE (user: User { name: \"Balmung\",  level: 99 })".query[Unit].execute(s)
       user <- "MATCH (user: User { name: \"Balmung\" }) RETURN user".query[User].single(s)
     } yield assert(user == User(name = "Balmung", level = 99))
   }
 
-  it should "fail if a single value does not satisfy the refinement condition" in execute { s =>
+  it should "fail if a single value does not satisfy the refinement condition" in executeAsFuture { s =>
     recoverToSucceededIf[IncoercibleException] {
       for {
         _ <- "CREATE (level: Level { value: -1 })".query[Unit].execute(s)
@@ -64,7 +64,7 @@ final class RefinedSpec extends CleaningIntegrationSpec[Future](FutureTestkit) {
     }
   }
 
-  it should "fail if at least one of multiple values does not satisfy the refinement condition" in execute { s =>
+  it should "fail if at least one of multiple values does not satisfy the refinement condition" in executeAsFuture { s =>
     recoverToSucceededIf[IncoercibleException] {
       for {
         _ <- "CREATE (level: Level { value: 3 })".query[Unit].execute(s)
@@ -75,7 +75,7 @@ final class RefinedSpec extends CleaningIntegrationSpec[Future](FutureTestkit) {
     }
   }
 
-  it should "fail if at least one wrapped value does not satisfy the refinement condition" in execute { s =>
+  it should "fail if at least one wrapped value does not satisfy the refinement condition" in executeAsFuture { s =>
     recoverToSucceededIf[IncoercibleException] {
       for {
         _ <- "CREATE (levels: Levels { values: [3, -1, 5] })".query[Unit].execute(s)
@@ -84,7 +84,7 @@ final class RefinedSpec extends CleaningIntegrationSpec[Future](FutureTestkit) {
     }
   }
 
-  it should "fail if at least one value inside a case class does not satisfy the refinement condition" in execute { s =>
+  it should "fail if at least one value inside a case class does not satisfy the refinement condition" in executeAsFuture { s =>
     recoverToSucceededIf[IncoercibleException] {
       for {
         _ <- "CREATE (user: User { name: \"???\", level: -1 })".query[Unit].execute(s)

--- a/site/src/main/mdoc/driver_session_transaction.md
+++ b/site/src/main/mdoc/driver_session_transaction.md
@@ -10,14 +10,14 @@ position: 100
 These three classes are the main points of interactions with a **Neo4j** database.
 
 A `Driver` is basically the connection with the Database. Usually, you would only need one instance per application, unless you need to connect to two different databases.<br>
-A `Session` provides a context for performing operations _(`Transactions`)_ over the database. You may need as many as concurrent operations you want to have.
+A `Session` provides a context for performing operations _(`Transaction`s)_ over the database. You may need as many as concurrent operations you want to have.
 A `Transaction` is a logical container for an atomic unit of work. Only one transaction may exist in a `Session` at any point in time.
 
 ## Session thread safety
 
 Unlike its **Java** counterpart, `neotypes.Session` is thread safe.
-We achieve that by using a simple locking mechanism that ensures only one `Transaction` can be created `Session`.
-If you want / need to run multiple queries concurrently then you need to create multiple `Sessions` and load-balance the petitions across them yourself.
+We achieve that by using a simple locking mechanism that ensures only one `Transaction` at a time for each `Session`.
+If you want / need to run multiple queries concurrently, then you need to create multiple `Session`s and load-balance the queries across them yourself.
 
 > **Note**: For all _pure_ effects, the blocking of the locks is semantic _(meaning no real thread was blocked)_.
 For `Future` we do a _best effort_ by using `scala.concurrent.blocking` to notify the EC that the following action will block.
@@ -26,7 +26,7 @@ For `Future` we do a _best effort_ by using `scala.concurrent.blocking` to notif
 
 Each `Transaction` has to be started, used and finally, either committed or rolled back.
 
-**neotypes** provides 3 ways of interacting with `Transactions`, designed for different use cases.
+**neotypes** provides 3 ways of interacting with `Transaction`s, designed for different use cases.
 
 ### Single query + automatic commit / rollback.
 
@@ -111,7 +111,7 @@ val config = TransactionConfig(
 )
 ```
 
-Which you can use in operations that explicitly or implicitly create `Transactions`.
+Which you can use in operations that explicitly or implicitly create `Transaction`s.
 
 
 ```scala mdoc:compile-only

--- a/site/src/main/mdoc/overview.md
+++ b/site/src/main/mdoc/overview.md
@@ -61,7 +61,6 @@ The import `neotypes.implicits.all._` adds an extension method `query[T]` to eac
 
 ```scala mdoc:invisible
 import neotypes.implicits.all._
-import scala.concurrent.ExecutionContext.Implicits.global
 def session: neotypes.Session[scala.concurrent.Future] = ???
 ```
 

--- a/site/src/main/mdoc/streams.md
+++ b/site/src/main/mdoc/streams.md
@@ -63,6 +63,8 @@ import neotypes.implicits.mappers.results._ // Brings the implicit ResultMapper[
 import neotypes.implicits.syntax.string._ // Provides the query[T] extension method.
 import org.neo4j.driver.AuthTokens
 
+implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
+
 val session: Resource[IO, Session[IO]] = for {
   driver <- GraphDatabase.driver[IO]("bolt://localhost:7687", AuthTokens.basic("neo4j", "****"))
   session <- driver.session
@@ -159,6 +161,7 @@ import cats.effect.IO
 import neotypes.implicits.all._
 import neotypes.cats.effect.implicits._
 import neotypes.fs2.implicits._
+implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
 def query: neotypes.DeferredQuery[String] = ???
 def session: neotypes.Session[IO] = ???
 ```

--- a/zio/src/test/scala/neotypes/zio/ZioTaskSuite.scala
+++ b/zio/src/test/scala/neotypes/zio/ZioTaskSuite.scala
@@ -12,6 +12,9 @@ object ZioTaskTestkit extends EffectTestkit[Task] {
     new Behaviour {
       val runtime = Runtime.default.mapPlatform(_ => Platform.fromExecutionContext(ec))
 
+      override final def fToT[T](task: Task[T]): T =
+        runtime.unsafeRun(task)
+
       override final def fToFuture[T](task: Task[T]): Future[T] =
         runtime.unsafeRunToFuture(task)
 


### PR DESCRIPTION
Fixes #44 

Adding a simple locking mechanism which ensures only one **Transaction** per **Session** can be active at time.
For pure effect types, the block for the lock is just semantic _(meaning no real thread is blocked)_. For **Future**, I used `blocking` which will notify the EC that the next operation will block; that is a _best effort_ since the EC may decide to allocate a new thread for not blocking a compute thread, but it may also just ignore it.

------

## Edit

~I still need to update the documentation to be very explicit about how this works and made clear that when not using managed transactions one has to be very careful of just calling  `commit` or `rollback` once; otherwise, the system is left in unspecified behavior _(most probably a failure or a deadlock)_.~

Done.