### PR TITLE
Fix id handling

### DIFF
--- a/core/src/main/scala/neotypes/Constants.scala
+++ b/core/src/main/scala/neotypes/Constants.scala
@@ -1,5 +1,0 @@
-package neotypes
-
-object Constants {
-  final val ID_FIELD_NAME: String = "id"
-}

--- a/core/src/main/scala/neotypes/implicits/mappers/ResultMappers.scala
+++ b/core/src/main/scala/neotypes/implicits/mappers/ResultMappers.scala
@@ -120,8 +120,11 @@ trait ResultMappers extends ValueMappers {
                                                                   head: ValueMapper[H],
                                                                   tail: ResultMapper[T]): ResultMapper[FieldType[K, H] :!: T] =
     new ResultMapper[FieldType[K, H] :!: T] {
-      private def collectEntityFields(entity: Entity): List[(String, Value)] =
-        (Constants.ID_FIELD_NAME -> new IntegerValue(entity.id)) :: getKeyValuesFrom(entity).toList
+      private def collectEntityFields(entity: Entity): List[(String, Value)] = {
+        val entityId = new IntegerValue(entity.id())
+        val ids = ("id" -> entityId) :: ("_id" -> entityId) :: Nil
+        (getKeyValuesFrom(entity) ++ ids).toList
+      }
 
       override def to(value: List[(String, Value)], typeHint: Option[TypeHint]): Either[Throwable, FieldType[K, H] :!: T] = {
         val fieldName = key.value.name

--- a/core/src/test/scala/neotypes/BasicSessionSpec.scala
+++ b/core/src/test/scala/neotypes/BasicSessionSpec.scala
@@ -1,6 +1,6 @@
 package neotypes
 
-import neotypes.implicits.mappers.results._
+import neotypes.implicits.mappers.all._
 import neotypes.implicits.syntax.string._
 import neotypes.internal.syntax.async._
 import org.neo4j.driver.types.Node
@@ -139,6 +139,45 @@ final class BasicSessionSpec[F[_]](testkit: EffectTestkit[F]) extends BaseIntegr
     }
   }
 
+  it should "correctly handle id fields" in executeAsFuture { s =>
+    for {
+      _ <- "CREATE (n: WithId { name: 'node1' })".query[Unit].execute(s)
+      _ <- "CREATE (n: WithId { name: 'node2', id: 135 })".query[Unit].execute(s)
+      _ <- "CREATE (n: WithId { name: 'node3', _id: 135 })".query[Unit].execute(s)
+      _ <- "CREATE (n: WithId { name: 'node4', id: 135, _id: 531 })".query[Unit].execute(s)
+      node1 <- "MATCH (n: WithId { name: 'node1' }) RETURN n, id(n)".query[(WithId, Int)].single(s)
+      node2 <- "MATCH (n: WithId { name: 'node2' }) RETURN n, id(n)".query[(WithId, Int)].single(s)
+      node3 <- "MATCH (n: WithId { name: 'node3' }) RETURN n, id(n)".query[(WithId, Int)].single(s)
+      node4 <- "MATCH (n: WithId { name: 'node4' }) RETURN n, id(n)".query[(WithId, Int)].single(s)
+    } yield {
+      // Node 1 doesn't have a custom id property.
+      // Thus the id field should contains the neo4j id.
+      assert(node1._1.id == node1._2)
+
+      // Node 2 has a custom id property.
+      // Thus the id field should contain the custom id,
+      // and the _id field should contain the neo4j id.
+      assert(node2._1.id == 135)
+      assert(node2._1._id.isDefined)
+      assert(node2._1._id.get == node2._2)
+
+      // Node 3 has a custom _id property.
+      // Thus the id field should contain the neo4j id,
+      // and the _id field should contain the custom id.
+      assert(node3._1.id == node3._2)
+      assert(node3._1._id.isDefined)
+      assert(node3._1._id.get == 135)
+
+      // Node 4 has both a custom id & _id properties.
+      // Thus both properties should contain the custom ids,
+      // and the system id is unreachable.
+      assert(node4._1.id == 135)
+      assert(node4._1._id.isDefined)
+      assert(node4._1._id.get == 531)
+    }
+  }
+
+
   override final val initQuery: String = BaseIntegrationSpec.DEFAULT_INIT_QUERY
 }
 
@@ -158,4 +197,6 @@ object BasicSessionSpec {
   final case class PersonWithRoles(person: Person, roles: Roles)
 
   final case class WrappedName(name: Option[String])
+
+  final case class WithId(id: Int, name: String, _id: Option[Int])
 }

--- a/core/src/test/scala/neotypes/BasicSessionSpec.scala
+++ b/core/src/test/scala/neotypes/BasicSessionSpec.scala
@@ -150,31 +150,29 @@ final class BasicSessionSpec[F[_]](testkit: EffectTestkit[F]) extends BaseIntegr
       node3 <- "MATCH (n: WithId { name: 'node3' }) RETURN n, id(n)".query[(WithId, Int)].single(s)
       node4 <- "MATCH (n: WithId { name: 'node4' }) RETURN n, id(n)".query[(WithId, Int)].single(s)
     } yield {
-      // Node 1 doesn't have a custom id property.
-      // Thus the id field should contains the neo4j id.
+      // Node 1 doesn't have any custom id property.
+      // Thus the id field should contain the neo4j id.
+      // and the _id field should also contain the neo4j id.
       assert(node1._1.id == node1._2)
-      assert(node1._1._id.isEmpty)
+      assert(node1._1._id == node1._2)
 
       // Node 2 has a custom id property.
       // Thus the id field should contain the custom id,
       // and the _id field should contain the neo4j id.
       assert(node2._1.id == 135)
-      assert(node2._1._id.isDefined)
-      assert(node2._1._id.get == node2._2)
+      assert(node2._1._id == node2._2)
 
       // Node 3 has a custom _id property.
       // Thus the id field should contain the neo4j id,
       // and the _id field should contain the custom id.
       assert(node3._1.id == node3._2)
-      assert(node3._1._id.isDefined)
-      assert(node3._1._id.get == 135)
+      assert(node3._1._id == 135)
 
       // Node 4 has both a custom id & _id properties.
       // Thus both properties should contain the custom ids,
       // and the system id is unreachable.
       assert(node4._1.id == 135)
-      assert(node4._1._id.isDefined)
-      assert(node4._1._id.get == 531)
+      assert(node4._1._id == 531)
     }
   }
 
@@ -198,5 +196,5 @@ object BasicSessionSpec {
 
   final case class WrappedName(name: Option[String])
 
-  final case class WithId(id: Int, name: String, _id: Option[Int])
+  final case class WithId(id: Int, name: String, _id: Int)
 }

--- a/core/src/test/scala/neotypes/BasicSessionSpec.scala
+++ b/core/src/test/scala/neotypes/BasicSessionSpec.scala
@@ -153,6 +153,7 @@ final class BasicSessionSpec[F[_]](testkit: EffectTestkit[F]) extends BaseIntegr
       // Node 1 doesn't have a custom id property.
       // Thus the id field should contains the neo4j id.
       assert(node1._1.id == node1._2)
+      assert(node1._1._id.isEmpty)
 
       // Node 2 has a custom id property.
       // Thus the id field should contain the custom id,
@@ -176,7 +177,6 @@ final class BasicSessionSpec[F[_]](testkit: EffectTestkit[F]) extends BaseIntegr
       assert(node4._1._id.get == 531)
     }
   }
-
 
   override final val initQuery: String = BaseIntegrationSpec.DEFAULT_INIT_QUERY
 }

--- a/site/src/main/mdoc/types.md
+++ b/site/src/main/mdoc/types.md
@@ -56,16 +56,28 @@ position: 30
 
 If you want to support your own types, then you would need to create your own _implicits_.
 
-* For **fields of a case class**, you need an instance of `neotypes.mappers.ValueMapper[T]`. You can create a new instace:
+* For **fields of a case class**, you need an instance of `neotypes.mappers.ValueMapper[T]`. You can create a new instance:
   + From scratch by instantiating it `new ValueMapper[T] { ... }`.
   + Using the helper methods on the companion object like `fromCast` or `instance`.
   + Casting an already existing mapper using `map` or `flatMap`.
 
-* For **query results**, you need an instance of `neotypes.mappers.ResultMapper[T]`. You can create a new instace:
+* For **query results**, you need an instance of `neotypes.mappers.ResultMapper[T]`. You can create a new instance:
   + From scratch by instantiating it `new ResultMapper[T] { ... }`.
   + From a **ValueMapper** `ResultMapper.fromValueMapper[T]`.
-  + Using the helper methods on the companion object like `instace`.
+  + Using the helper methods on the companion object like `instance`.
   + Casting an already existing mapper using `map` or `flatMap`.
 
-* For **query parameters**, you need an instance of `neotypes.mappers.ParameterMapper[T]`. You can create a new instace:
+* For **query parameters**, you need an instance of `neotypes.mappers.ParameterMapper[T]`. You can create a new instance:
   + Casting an already existing mapper using `contramap`.
+
+# Neo4j Id
+
+Even if [**neo4j** does not recommend the use of the of the system id](https://neo4j.com/blog/dark-side-neo4j-worst-practices/), **neotypes** allows you to easily retrieve it.
+You only need to ask for a property named `id` on your case classes.
+
+Note: If your model also defines a custom `id` property, then your property will take precedence and we will return you that one instead of the system one.
+If you also need the system one then you can ask for the `_id` property.
+If you have a custom `_id` property, then yours will take precedence and the system id will be available in the `id` property.
+If you define both `id` and `_id` as custom properties, then both will take precedence and the system id would be unreachable.
+
+> Disclaimer: we also discourage you from using the system id; we only allow you to access it because the Java driver does.


### PR DESCRIPTION
This PR ensures **neotypes** always prioritize custom defined `id` fields instead of the **neo4j** one.