### PR TITLE
Support case class by cypher string interpolator

### DIFF
--- a/core/src/main/scala/neotypes/CypherStringInterpolator.scala
+++ b/core/src/main/scala/neotypes/CypherStringInterpolator.scala
@@ -1,5 +1,7 @@
 package neotypes
 
+import generic.Exported
+import mappers.ParameterMapper
 import types.QueryParam
 
 import scala.reflect.macros.blackbox
@@ -9,24 +11,50 @@ final class CypherStringInterpolator(private val sc: StringContext) extends AnyV
 }
 
 object CypherStringInterpolator {
-  def createQuery(sc: StringContext)(parameters: QueryParam*): DeferredQueryBuilder = {
-    val queries = sc.parts.iterator.map(DeferredQueryBuilder.Query)
-    val params = parameters.iterator.map(DeferredQueryBuilder.Param)
 
-    val queryParts = new Iterator[DeferredQueryBuilder.Part] {
-      private var paramNext: Boolean = false
-      override def hasNext: Boolean = queries.hasNext
-      override def next(): DeferredQueryBuilder.Part =
-        if (paramNext && params.hasNext) {
-          paramNext = false
-          params.next()
-        } else {
-          paramNext = true
-          queries.next()
+  def createQuery(sc: StringContext)(parameters: QueryArg*): DeferredQueryBuilder = {
+    val queries = sc.parts.iterator
+    val params = parameters.iterator
+
+    @annotation.tailrec
+    def loop(paramNext: Boolean, output: List[DeferredQueryBuilder.Part]): List[DeferredQueryBuilder.Part] =
+      if (paramNext && params.hasNext) {
+        params.next() match {
+          case QueryArg.Param(value)      => loop(paramNext = false, output :+ DeferredQueryBuilder.Param(value))
+          case QueryArg.CaseClass(params) => loop(paramNext = false, output ++ caseClassParts(params))
         }
+      } else if (queries.hasNext) {
+        loop(paramNext = true, output :+ DeferredQueryBuilder.Query(queries.next()))
+      } else {
+        output
+      }
+
+    val queryParts = loop(paramNext = false, Nil)
+
+    new DeferredQueryBuilder(queryParts)
+  }
+
+  private val CommaQuery = DeferredQueryBuilder.Query(",")
+
+  private def caseClassParts(params: Map[String, QueryParam]): List[DeferredQueryBuilder.Part] = {
+
+    @scala.inline
+    def makeParts(label: String, queryParam: QueryParam, last: Boolean): List[DeferredQueryBuilder.Part] = {
+      val query = DeferredQueryBuilder.Query(label + ": ")
+      val param = DeferredQueryBuilder.Param(queryParam)
+
+      if (last) List(query, param) else List(query, param, CommaQuery)
     }
 
-    new DeferredQueryBuilder(queryParts.toList)
+    @annotation.tailrec
+    def loop(input: List[(String, QueryParam)], output: List[DeferredQueryBuilder.Part]): List[DeferredQueryBuilder.Part] =
+      input match {
+        case Nil => output
+        case (label, param) :: Nil => output ++ makeParts(label, param, last = true)
+        case (label, param) :: tail => loop(tail, output ++ makeParts(label, param, last = false))
+      }
+
+    loop(params.toList, Nil)
   }
 
   def macroImpl(c: blackbox.Context)(args: c.Expr[Any]*): c.Expr[DeferredQueryBuilder] = {
@@ -39,11 +67,58 @@ object CypherStringInterpolator {
       val nextElement = arg.tree
       val tpe = nextElement.tpe.widen
 
-      q"neotypes.mappers.ParameterMapper[${tpe}].toQueryParam(${nextElement})"
+      q"_root_.neotypes.QueryArgMapper[${tpe}].toArg(${nextElement})"
     }
 
     c.Expr(
-      q"neotypes.CypherStringInterpolator.createQuery(${sc})(..${parameters})"
+      q"_root_.neotypes.CypherStringInterpolator.createQuery(${sc})(..${parameters})"
     )
   }
+}
+
+sealed trait QueryArg
+
+object QueryArg {
+  final case class Param(value: QueryParam) extends QueryArg
+  final case class CaseClass(params: Map[String, QueryParam]) extends QueryArg
+}
+
+@annotation.implicitNotFound("Could not find the QueryArgMapper for ${A}.")
+trait QueryArgMapper[A] {
+  def toArg(value: A): QueryArg
+}
+
+object QueryArgMapper extends QueryOrgMappersLowPriority {
+
+  def apply[A](implicit ev: QueryArgMapper[A]): QueryArgMapper[A] = ev
+
+  implicit def fromParameterMapper[A: ParameterMapper]: QueryArgMapper[A] =
+    (a: A) => QueryArg.Param(ParameterMapper[A].toQueryParam(a))
+
+}
+
+trait QueryOrgMappersLowPriority {
+  implicit def fromCaseClassArgMapper[A: CaseClassArgMapper]: QueryArgMapper[A] =
+    CaseClassArgMapper[A]
+}
+
+@annotation.implicitNotFound(
+"""
+Could not find the CaseClassArgMapper for ${A}.
+
+Import `neotypes.generic.auto._` for the automated derivation, or use the semiauto one:
+`implicit val instance: CaseClassArgMapper[A] = neotypes.generic.semiauto.deriveCaseClassArgMapper`
+"""
+)
+trait CaseClassArgMapper[A] extends QueryArgMapper[A] {
+  def toArg(value: A): QueryArg.CaseClass
+}
+
+object CaseClassArgMapper extends CaseClassArgMappersLowPriority {
+  def apply[A](implicit ev: CaseClassArgMapper[A]): CaseClassArgMapper[A] = ev
+}
+
+trait CaseClassArgMappersLowPriority {
+  implicit final def exportedCaseClassArgMapper[A](implicit exported: Exported[CaseClassArgMapper[A]]): CaseClassArgMapper[A] =
+    exported.instance
 }

--- a/core/src/main/scala/neotypes/DeferredQuery.scala
+++ b/core/src/main/scala/neotypes/DeferredQuery.scala
@@ -352,7 +352,7 @@ private[neotypes] object DeferredQuery {
   *
   * val deferredQueryBuilder = c"create (a: Person { name: \$name," + c"born: \$born })"
   *
-  * val deferredQuery = defferedQueryBuilder.query[Unit]
+  * val deferredQuery = deferredQueryBuilder.query[Unit]
   * }}}
   */
 final class DeferredQueryBuilder private[neotypes] (private val parts: List[DeferredQueryBuilder.Part]) {

--- a/core/src/main/scala/neotypes/generic/DerivedCaseClassArgMapper.scala
+++ b/core/src/main/scala/neotypes/generic/DerivedCaseClassArgMapper.scala
@@ -1,0 +1,39 @@
+package neotypes.generic
+
+import neotypes.mappers.ParameterMapper
+import neotypes.{CaseClassArgMapper, QueryArg}
+import neotypes.types.QueryParam
+
+import shapeless.labelled.FieldType
+import shapeless.ops.hlist.MapFolder
+import shapeless.{HList, LabelledGeneric, Poly1, Witness}
+
+trait DerivedCaseClassArgMapper[A] extends CaseClassArgMapper[A]
+
+object DerivedCaseClassArgMapper {
+
+  implicit def deriveCaseClassArgMapper[T <: Product, R <: HList](implicit ev: LabelledGeneric.Aux[T, R],
+                                                            folder: MapFolder[R, Map[String, QueryParam], parameterMapper.type]): DerivedCaseClassArgMapper[T] =
+    new DerivedCaseClassArgMapper[T] {
+      override def toArg(value: T): QueryArg.CaseClass = {
+        QueryArg.CaseClass(folder.apply(ev.to(value), Map.empty, _ ++ _))
+      }
+    }
+
+  object parameterMapper extends LowPriority {
+    implicit def optional[K <: Symbol, V: ParameterMapper](implicit key: Witness.Aux[K]): Case.Aux[FieldType[K, Option[V]], Map[String, QueryParam]] =
+      at[FieldType[K, Option[V]]] { v =>
+        (v: Option[V]).fold[Map[String, QueryParam]](Map.empty)(v =>
+          Map(key.value.name -> ParameterMapper[V].toQueryParam(v))
+        )
+      }
+  }
+
+  trait LowPriority extends Poly1 {
+    implicit def all[K <: Symbol, V: ParameterMapper](implicit key: Witness.Aux[K]): Case.Aux[FieldType[K, V], Map[String, QueryParam]] =
+      at[FieldType[K, V]] { (v: V) =>
+        Map(key.value.name -> ParameterMapper[V].toQueryParam(v))
+      }
+  }
+
+}

--- a/core/src/main/scala/neotypes/generic/ExportMacros.scala
+++ b/core/src/main/scala/neotypes/generic/ExportMacros.scala
@@ -1,6 +1,7 @@
 package neotypes.generic
 
 import neotypes.mappers.ResultMapper
+import neotypes.CaseClassArgMapper
 
 import scala.reflect.macros.blackbox
 
@@ -17,6 +18,19 @@ private[generic] class ExportMacros(val c: blackbox.Context) {
       case t =>
         c.Expr[Exported[ResultMapper[A]]](
           q"new _root_.neotypes.generic.Exported($t: _root_.neotypes.mappers.ResultMapper[$A])"
+        )
+    }
+  }
+
+  final def exportCaseClassArgMapper[C[x] <: CaseClassArgMapper[x], A](implicit C: c.WeakTypeTag[C[_]],
+                                                                 A: c.WeakTypeTag[A]): c.Expr[Exported[CaseClassArgMapper[A]]] = {
+    val target = appliedType(C.tpe.typeConstructor, A.tpe)
+
+    c.typecheck(q"_root_.shapeless.lazily[$target]", silent = false) match {
+      case EmptyTree => c.abort(c.enclosingPosition, s"Unable to infer value of type $target")
+      case t =>
+        c.Expr[Exported[CaseClassArgMapper[A]]](
+          q"new _root_.neotypes.generic.Exported($t: _root_.neotypes.CaseClassArgMapper[$A])"
         )
     }
   }

--- a/core/src/main/scala/neotypes/generic/auto.scala
+++ b/core/src/main/scala/neotypes/generic/auto.scala
@@ -1,6 +1,7 @@
 package neotypes.generic
 
 import neotypes.mappers.ResultMapper
+import neotypes.CaseClassArgMapper
 
 import shapeless.HList
 
@@ -12,4 +13,6 @@ object auto {
   implicit final def exportProductResultMapper[P <: Product]: Exported[ResultMapper[P]] =
     macro ExportMacros.exportResultMapper[DerivedResultMapper, P]
 
+  implicit final def exportCaseClassArgMapper[P <: Product]: Exported[CaseClassArgMapper[P]] =
+    macro ExportMacros.exportCaseClassArgMapper[DerivedCaseClassArgMapper, P]
 }

--- a/core/src/main/scala/neotypes/generic/semiauto.scala
+++ b/core/src/main/scala/neotypes/generic/semiauto.scala
@@ -1,7 +1,7 @@
 package neotypes.generic
 
 import neotypes.mappers.ResultMapper
-
+import neotypes.CaseClassArgMapper
 import shapeless.{HList, Lazy}
 
 object semiauto {
@@ -10,6 +10,9 @@ object semiauto {
     mapper.value
 
   final def deriveProductResultMapper[P <: Product](implicit mapper: Lazy[DerivedResultMapper[P]]): ResultMapper[P] =
+    mapper.value
+
+  final def deriveCaseClassArgMapper[P <: Product](implicit mapper: Lazy[DerivedCaseClassArgMapper[P]]): CaseClassArgMapper[P] =
     mapper.value
 
 }

--- a/core/src/test/scala/neotypes/ConcurrentSessionSpec.scala
+++ b/core/src/test/scala/neotypes/ConcurrentSessionSpec.scala
@@ -1,7 +1,6 @@
 package neotypes
 
 import neotypes.internal.syntax.async._
-import neotypes.implicits.mappers.all._
 import neotypes.implicits.syntax.cypher._
 import org.scalatest.matchers.should.Matchers
 import scala.concurrent.ExecutionContext

--- a/core/src/test/scala/neotypes/CypherQueryInterpolationSpec.scala
+++ b/core/src/test/scala/neotypes/CypherQueryInterpolationSpec.scala
@@ -141,10 +141,35 @@ final class CypherQueryInterpolationSpec extends AnyFlatSpec {
 
     assert(query.query == expected)
   }
+
+  it should "interpolation with case classes and a relationship" in {
+    val user = User("Joan", 20)
+    val cat = Cat("Waffles", 3)
+    val relationship = HasCatRelationship(2)
+
+    val query = c"CREATE (u: User { $user }) -[r:HAS_CAT { $relationship }]->(c:Cat { $cat }) RETURN r"
+
+    val expected = DeferredQuery(
+      query = """CREATE (u: User {  name: $p1, age: $p2 }) -[r:HAS_CAT {  friendsFor: $p3 }]->(c:Cat {  tag: $p4, age: $p5 }) RETURN r""",
+      params = Map(
+        "p1" -> QueryParam(user.name),
+        "p2" -> QueryParam(user.age),
+        "p3" -> QueryParam(relationship.friendsFor),
+        "p4" -> QueryParam(cat.tag),
+        "p5" -> QueryParam(cat.age)
+      )
+    )
+
+    assert(query.query == expected)
+  }
 }
 
 object CypherQueryInterpolationSpec {
 
   case class TestClass(name: String, age: Int)
+
+  case class User(name: String, age: Int)
+  case class Cat(tag: String, age: Int)
+  case class HasCatRelationship(friendsFor: Int)
 
 }

--- a/core/src/test/scala/neotypes/CypherQueryInterpolationSpec.scala
+++ b/core/src/test/scala/neotypes/CypherQueryInterpolationSpec.scala
@@ -150,13 +150,31 @@ final class CypherQueryInterpolationSpec extends AnyFlatSpec {
     val query = c"CREATE (u: User { $user }) -[r:HAS_CAT { $relationship }]->(c:Cat { $cat }) RETURN r"
 
     val expected = DeferredQuery(
-      query = """CREATE (u: User {  name: $p1, age: $p2 }) -[r:HAS_CAT {  friendsFor: $p3 }]->(c:Cat {  tag: $p4, age: $p5 }) RETURN r""",
+      query = "CREATE (u: User {  name: $p1, age: $p2 }) -[r:HAS_CAT {  friendsFor: $p3 }]->(c:Cat {  tag: $p4, age: $p5 }) RETURN r",
       params = Map(
         "p1" -> QueryParam(user.name),
         "p2" -> QueryParam(user.age),
         "p3" -> QueryParam(relationship.friendsFor),
         "p4" -> QueryParam(cat.tag),
         "p5" -> QueryParam(cat.age)
+      )
+    )
+
+    assert(query.query == expected)
+  }
+
+  it should "interpolation with a case classes and an extra property" in {
+    val user = User("Joan", 20)
+    val extraProp = 123
+
+    val query = c"CREATE (u: User { $user, extraProperty: $extraProp }) RETURN u"
+
+    val expected = DeferredQuery(
+      query = "CREATE (u: User {  name: $p1, age: $p2, extraProperty: $p3 }) RETURN u",
+      params = Map(
+        "p1" -> QueryParam(user.name),
+        "p2" -> QueryParam(user.age),
+        "p3" -> QueryParam(extraProp)
       )
     )
 

--- a/core/src/test/scala/neotypes/ParameterSpec.scala
+++ b/core/src/test/scala/neotypes/ParameterSpec.scala
@@ -2,7 +2,6 @@ package neotypes
 
 import java.time.{Duration, LocalDate, LocalDateTime, LocalTime, Period, OffsetDateTime, OffsetTime, ZonedDateTime}
 import java.util.UUID
-import neotypes.implicits.mappers.all._
 import neotypes.implicits.syntax.cypher._
 import neotypes.implicits.syntax.string._
 import neotypes.internal.syntax.async._

--- a/core/src/test/scala/neotypes/generic/CaseClassArgMapperAutoSpec.scala
+++ b/core/src/test/scala/neotypes/generic/CaseClassArgMapperAutoSpec.scala
@@ -1,0 +1,90 @@
+package neotypes.generic
+
+import neotypes.{CaseClassArgMapper, QueryArg}
+import neotypes.types.QueryParam
+
+import org.scalatest.freespec.AnyFreeSpec
+
+final class CaseClassArgMapperAutoSpec extends AnyFreeSpec {
+
+  import CaseClassArgMapperAutoSpec._
+
+  "neotypes.generic.auto._" - {
+
+    import neotypes.generic.auto._
+
+    "should derive an instance of a product (case class)" in {
+      val mapper = CaseClassArgMapper[MyCaseClass]
+      val input = MyCaseClass("twelve chars", 12)
+      val result = mapper.toArg(input)
+
+      val expected = QueryArg.CaseClass(
+        Map(
+          "string" -> QueryParam("twelve chars"),
+          "int" -> QueryParam(12)
+        )
+      )
+
+      assert(result == expected)
+    }
+
+    "should derive an instance of a product (tuple)" in {
+      val mapper = CaseClassArgMapper[(String, Int)]
+      val input = ("twelve chars", 12)
+      val result = mapper.toArg(input)
+
+      val expected = QueryArg.CaseClass(
+        Map(
+          "_1" -> QueryParam("twelve chars"),
+          "_2" -> QueryParam(12)
+        )
+      )
+
+      assert(result == expected)
+    }
+
+    "should prioritize an instance from companion object over derived" in {
+      val mapper = CaseClassArgMapper[ObjectScopeCaseClassArgMapper]
+      val input = ObjectScopeCaseClassArgMapper("const?")
+
+      val expected = QueryArg.CaseClass(Map("const" -> QueryParam("const")))
+
+      assert(mapper.toArg(input) == expected)
+    }
+
+    "should not derive an instance of nested classes" in {
+      assertCompiles("CaseClassArgMapper[MyCaseClass]")
+      assertDoesNotCompile("CaseClassArgMapper[(MyCaseClass, MyCaseClass)]")
+      assertDoesNotCompile("CaseClassArgMapper[NestedCaseClass]")
+    }
+
+    "should not derive an instance of a HList" in {
+      assertDoesNotCompile(
+        """
+          |import shapeless._
+          |CaseClassArgMapper[String :: Int :: HNil]
+          |""".stripMargin
+      )
+    }
+
+  }
+
+}
+
+object CaseClassArgMapperAutoSpec {
+
+  final case class MyCaseClass(string: String, int: Int)
+
+  final case class NestedCaseClass(value: String, nested: MyCaseClass)
+
+  final case class ObjectScopeCaseClassArgMapper(value: String)
+
+  object ObjectScopeCaseClassArgMapper {
+    implicit val caseClassArgMapper: CaseClassArgMapper[ObjectScopeCaseClassArgMapper] =
+      new CaseClassArgMapper[ObjectScopeCaseClassArgMapper] {
+        override def toArg(value: ObjectScopeCaseClassArgMapper): QueryArg.CaseClass =
+          QueryArg.CaseClass(Map("const" -> QueryParam("const")))
+      }
+  }
+
+}

--- a/core/src/test/scala/neotypes/generic/CaseClassArgMapperSemiautoSpec.scala
+++ b/core/src/test/scala/neotypes/generic/CaseClassArgMapperSemiautoSpec.scala
@@ -1,0 +1,72 @@
+package neotypes.generic
+
+import neotypes.{CaseClassArgMapper, QueryArg}
+import neotypes.types.QueryParam
+
+import org.scalatest.freespec.AnyFreeSpec
+
+final class CaseClassArgMapperSemiautoSpec extends AnyFreeSpec {
+
+  import CaseClassArgMapperSemiautoSpec._
+
+  "neotypes.generic.semiauto._" - {
+
+    import neotypes.generic.semiauto._
+
+    "should derive an instance of a product (case class)" in {
+      val mapper: CaseClassArgMapper[MyCaseClass] = deriveCaseClassArgMapper
+      val input = MyCaseClass("twelve chars", 12)
+      val result = mapper.toArg(input)
+
+      val expected = QueryArg.CaseClass(
+        Map(
+          "string" -> QueryParam("twelve chars"),
+          "int" -> QueryParam(12)
+        )
+      )
+
+      assert(result == expected)
+    }
+
+    "should derive an instance of a product (tuple)" in {
+      val mapper: CaseClassArgMapper[(String, Int)] = deriveCaseClassArgMapper
+      val input = ("twelve chars", 12)
+      val result = mapper.toArg(input)
+
+      val expected = QueryArg.CaseClass(
+        Map(
+          "_1" -> QueryParam("twelve chars"),
+          "_2" -> QueryParam(12)
+        )
+      )
+
+      assert(result == expected)
+    }
+
+    "should not derive an instance of nested classes" in {
+      assertCompiles("deriveCaseClassArgMapper[MyCaseClass]")
+      assertDoesNotCompile("deriveCaseClassArgMapper[(MyCaseClass, MyCaseClass)]")
+      assertDoesNotCompile("deriveCaseClassArgMapper[NestedCaseClass]")
+    }
+
+    "should not derive an instance of a HList" in {
+      assertDoesNotCompile(
+        """
+          |import shapeless._
+          |deriveCaseClassArgMapper[String :: Int :: HNil]
+          |""".stripMargin
+      )
+    }
+
+  }
+
+}
+
+object CaseClassArgMapperSemiautoSpec {
+
+  final case class MyCaseClass(string: String, int: Int)
+
+  final case class NestedCaseClass(value: String, nested: MyCaseClass)
+
+}
+

--- a/site/src/main/mdoc/parameterized_queries.md
+++ b/site/src/main/mdoc/parameterized_queries.md
@@ -39,3 +39,23 @@ val LABEL = "User"
 val query2 = c"CREATE (a:" + LABEL + c"{name: $name})"
 query2.query[Unit]
 ```
+
+A case class can be used directly in the interpolation:
+
+```scala mdoc:nest
+import neotypes.generic.auto._
+
+case class User(name: String, born: Int)
+case class Cat(tag: String)
+case class HasCat(since: Int)
+
+val user = User("John", 1980)
+val cat = Cat("Waffles")
+val hasCat = HasCat(2010)
+
+val query1 = c"CREATE (u: User { $user })"
+query1.query[Unit]
+
+val query2 = c"CREATE (u: User { $user }) -[r:HAS_CAT { $hasCat }]->(c:Cat{ $cat }) RETURN r"
+query2.query[HasCat]
+```


### PR DESCRIPTION
It works the next way:

```scala
case class User(name: String, age: Int)
val user = User("my name", 33)

val query = c"""CREATE (u: User { $user }) RETURN u"""
// CREATE (u: User { name: "my name", age: 33 }) RETURN u
```