### PR TITLE
Adding version scheme

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,7 @@ ThisBuild / scmInfo ~= {
 ThisBuild / scalaVersion := "2.12.13"
 ThisBuild / crossScalaVersions := Seq("2.12.13", "2.13.5")
 ThisBuild / organization := "com.dimafeng"
+ThisBuild / versionScheme := Some("semver-spec")
 
 def removeScalacOptionsInTest(scalaVersion: String) =
   CrossVersion.partialVersion(scalaVersion) match {


### PR DESCRIPTION
Based on https://scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html#versionscheme-librarydependencyschemes-and-sbt-150
More info here: https://www.scala-sbt.org/1.x/docs/Publishing.html#Version+scheme

It may even be good to release a new version after merging this, so it is included in the **pom**; version `0.16.1`
what do you think @dimafeng ?