### PR TITLE
WIP: Support cats-effect 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,10 +11,10 @@ val mockitoVersion = "1.10.19"
 val scalaTestVersion = "3.2.8"
 val logbackVersion = "1.2.3"
 val catsVersion = "2.6.0"
-val catsEffectsVersion = "2.5.0"
+val catsEffectsVersion = "3.1.0"
 val monixVersion = "3.3.0"
 val akkaStreamVersion = "2.6.14"
-val fs2Version = "2.5.5"
+val fs2Version = "3.0.2"
 val zioVersion = "1.0.7"
 val zioInteropReactiveStreamsVersion = "1.3.4"
 val refinedVersion = "0.9.24"
@@ -166,8 +166,6 @@ lazy val monix = (project in file("monix"))
   .settings(
     name := "neotypes-monix",
     libraryDependencies ++= PROVIDED(
-      "org.typelevel" %% "cats-core" % catsVersion,
-      "org.typelevel" %% "cats-effect" % catsEffectsVersion,
       "io.monix" %% "monix-eval" % monixVersion
     )
   )
@@ -213,8 +211,6 @@ lazy val monixStream = (project in file("monix-stream"))
   .settings(
     name := "neotypes-monix-stream",
     libraryDependencies ++= PROVIDED(
-      "org.typelevel" %% "cats-core" % catsVersion,
-      "org.typelevel" %% "cats-effect" % catsEffectsVersion,
       "io.monix" %% "monix-eval" % monixVersion,
       "io.monix" %% "monix-reactive" % monixVersion
     )

--- a/cats-effect/src/main/scala/neotypes/cats/effect/CatsEffect.scala
+++ b/cats-effect/src/main/scala/neotypes/cats/effect/CatsEffect.scala
@@ -2,7 +2,7 @@ package neotypes.cats.effect
 
 import neotypes.exceptions.CancellationException
 
-import cats.effect.{Async, ExitCase, Resource}
+import cats.effect.{Async, Resource}
 
 trait CatsEffect {
   private[neotypes] final type FResource[F[_]] = { type R[A] = Resource[F, A] }
@@ -12,7 +12,7 @@ trait CatsEffect {
       override final type R[A] = Resource[F, A]
 
       override final def async[A](cb: (Either[Throwable, A] => Unit) => Unit): F[A] =
-        F.async(cb)
+        F.async_(cb)
 
       override final def delay[A](t: => A): F[A] =
         F.delay(t)
@@ -27,9 +27,9 @@ trait CatsEffect {
                                         (f: A => F[B])
                                         (finalizer: (A, Option[Throwable]) => F[Unit]): F[B] =
         Resource.makeCase(fa) {
-          case (a, ExitCase.Completed) => finalizer(a, None)
-          case (a, ExitCase.Canceled)  => finalizer(a, Some(CancellationException))
-          case (a, ExitCase.Error(ex)) => finalizer(a, Some(ex))
+          case (a, Resource.ExitCase.Succeeded)   => finalizer(a, None)
+          case (a, Resource.ExitCase.Canceled)    => finalizer(a, Some(CancellationException))
+          case (a, Resource.ExitCase.Errored(ex)) => finalizer(a, Some(ex))
         }.use(f)
 
       override final def map[A, B](m: F[A])(f: A => B): F[B] =

--- a/cats-effect/src/test/scala/neotypes/cats/effect/IOSuite.scala
+++ b/cats-effect/src/test/scala/neotypes/cats/effect/IOSuite.scala
@@ -3,7 +3,8 @@ package neotypes.cats.effect
 import neotypes.{Async, EffectSuite, EffectTestkit}
 import neotypes.cats.effect.implicits._
 
-import cats.effect.{ContextShift, IO}
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import cats.syntax.parallel._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -12,11 +13,8 @@ import scala.concurrent.{ExecutionContext, Future}
 object IOTestkit extends EffectTestkit[IO] {
   override def createBehaviour(implicit ec: ExecutionContext): Behaviour =
     new Behaviour {
-      implicit val cs: ContextShift[IO] =
-        IO.contextShift(ec)
-
       override final def fToFuture[A](io: IO[A]): Future[A] =
-        cs.evalOn(ec)(io).unsafeToFuture()
+        io.evalOn(ec).unsafeToFuture()
 
       override def runConcurrently(a: IO[Unit], b: IO[Unit]): IO[Unit] =
         (a, b).parMapN((_, _) => ())

--- a/fs2-stream/src/main/scala/neotypes/fs2/package.scala
+++ b/fs2-stream/src/main/scala/neotypes/fs2/package.scala
@@ -1,6 +1,6 @@
 package neotypes
 
-import _root_.cats.effect.{ContextShift, IO}
+import _root_.cats.effect.IO
 import _root_.fs2.{Stream => Fs2Stream}
 
 package object fs2 {
@@ -9,6 +9,6 @@ package object fs2 {
   type Fs2IoStream[A] = Fs2Stream[IO, A]
 
   final object implicits extends Fs2Streams {
-    implicit final def Fs2IoStream(implicit cs: ContextShift[IO]): Stream.Aux[Fs2IoStream, IO] = fs2Stream
+    implicit final def Fs2IoStream: Stream.Aux[Fs2IoStream, IO] = fs2Stream
   }
 }

--- a/fs2-stream/src/main/scala/neotypes/fs2/package.scala
+++ b/fs2-stream/src/main/scala/neotypes/fs2/package.scala
@@ -9,6 +9,6 @@ package object fs2 {
   type Fs2IoStream[A] = Fs2Stream[IO, A]
 
   final object implicits extends Fs2Streams {
-    implicit final def Fs2IoStream: Stream.Aux[Fs2IoStream, IO] = fs2Stream
+    implicit final val Fs2IoStream: Stream.Aux[Fs2IoStream, IO] = fs2Stream
   }
 }

--- a/fs2-stream/src/test/scala/neotypes/fs2/Fs2Suite.scala
+++ b/fs2-stream/src/test/scala/neotypes/fs2/Fs2Suite.scala
@@ -4,7 +4,7 @@ import neotypes.{Stream, StreamSuite, StreamTestkit}
 import neotypes.cats.effect.IOTestkit
 import neotypes.fs2.implicits._
 
-import cats.effect.{ContextShift, IO}
+import cats.effect.IO
 
 import scala.concurrent.ExecutionContext
 
@@ -12,9 +12,6 @@ import scala.concurrent.ExecutionContext
 object Fs2Testkit extends StreamTestkit[Fs2IoStream, IO](IOTestkit) {
   override def createBehaviour(implicit ec: ExecutionContext): Behaviour =
     new Behaviour {
-      implicit val cs: ContextShift[IO] =
-        IO.contextShift(ec)
-
       override def streamToFList[A](stream: Fs2IoStream[A]): IO[List[A]] =
         stream.compile.toList
 

--- a/site/src/main/mdoc/alternative_effects.md
+++ b/site/src/main/mdoc/alternative_effects.md
@@ -35,6 +35,7 @@ val data: String = Await.result(program, 1.second)
 
 ```scala mdoc:compile-only
 import cats.effect.{IO, Resource}
+import cats.effect.unsafe.implicits.global // Brings the implicit IORuntime instance into the scope.
 import neotypes.{GraphDatabase, Driver}
 import neotypes.cats.effect.implicits._ // Brings the implicit neotypes.Async[IO] instance into the scope.
 import neotypes.implicits.syntax.string._ // Provides the query[T] extension method.
@@ -54,6 +55,7 @@ val data: String = program.unsafeRunSync()
 
 ```scala mdoc:compile-only
 import cats.effect.{Async, IO, Resource}
+import cats.effect.unsafe.implicits.global // Brings the implicit IORuntime instance into the scope.
 import neotypes.{GraphDatabase, Driver}
 import neotypes.cats.effect.implicits._ // Brings the implicit neotypes.Async[IO] instance into the scope.
 import neotypes.implicits.syntax.string._ // Provides the query[T] extension method.
@@ -71,7 +73,7 @@ val data: String = program[IO].unsafeRunSync()
 
 ### monix.eval.Task _(neotypes-monix)_
 
-```scala mdoc:compile-only
+```scala
 import cats.effect.Resource
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global

--- a/site/src/main/mdoc/changelog.md
+++ b/site/src/main/mdoc/changelog.md
@@ -114,7 +114,7 @@ val data = fs2.Stream.resource(sessionR).flatMap { s =>
 }
 ```
 
-```scala mdoc:invisible
+```scala
 import cats.effect.{IO, Resource}
 import neotypes.{GraphDatabase, StreamingDriver}
 import neotypes.cats.effect.implicits._
@@ -125,7 +125,7 @@ import org.neo4j.driver.AuthTokens
 implicit val cs =IO.contextShift(scala.concurrent.ExecutionContext.global)
 ```
 
-```scala mdoc:compile-only
+```scala
 // With this:
 val driverR: Resource[IO, StreamingDriver[Fs2IoStream, IO]] =
   GraphDatabase.streamingDriver[Fs2IoStream]("bolt://localhost:7687", AuthTokens.basic("neo4j", "****"))

--- a/site/src/main/mdoc/streams.md
+++ b/site/src/main/mdoc/streams.md
@@ -52,6 +52,7 @@ Await.ready(program, 5.seconds)
 
 ```scala mdoc:compile-only
 import cats.effect.{IO, Resource}
+import cats.effect.unsafe.implicits.global // Brings the implicit IORuntime instance into the scope.
 import fs2.Stream
 import neotypes.{GraphDatabase, StreamingDriver}
 import neotypes.cats.effect.implicits._ // Brings the implicit Async[IO] instance into the scope.
@@ -59,9 +60,6 @@ import neotypes.fs2.Fs2IoStream
 import neotypes.fs2.implicits._ // Brings the implicit Stream[Fs2IOStream] instance into the scope.
 import neotypes.implicits.syntax.string._ // Provides the query[T] extension method.
 import org.neo4j.driver.AuthTokens
-
-implicit val cs =
-  IO.contextShift(scala.concurrent.ExecutionContext.global)
 
 val driver: Resource[IO, StreamingDriver[Fs2IoStream, IO]] =
   GraphDatabase.streamingDriver[Fs2IoStream]("bolt://localhost:7687", AuthTokens.basic("neo4j", "****"))
@@ -85,7 +83,7 @@ And replacing the `neotypes.fs2.Fs2IoStream` type alias with `neotypes.fs2.Fs2FS
 
 ### Monix Observables _(neotypes-monix-stream)_
 
-```scala mdoc:compile-only
+```scala
 import cats.effect.Resource
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
@@ -148,7 +146,6 @@ import cats.effect.IO
 import neotypes.GraphDatabase
 import neotypes.cats.effect.implicits._
 import neotypes.fs2.implicits._
-implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
 val uri: String = ""
 def query: neotypes.DeferredQuery[String] = ???
 ```


### PR DESCRIPTION
This PR brings support of cats-effect and fs2 3.x.

**Note:** a version of monix compatible with cats-effect 3 was not released yet. Therefore `monix` and `monix-stream` modules are still using cats-effect 2.