### PR TITLE
Update organization id

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > neotype - a type specimen that is selected subsequent to the description of a species to replace a preexisting type that has been lost or destroyed.
 
 ![CI](https://github.com/neotypes/neotypes/workflows/CI/badge.svg?branch=main)
-[![Maven Central](https://img.shields.io/maven-central/v/com.dimafeng/neotypes_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.dimafeng/neotypes_2.12)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.neotypes/neotypes-core_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/io.github.neotypes/neotypes-core_2.12)
 [![Gitter Chat](https://badges.gitter.im/neotypes-neotypes/Lobby.svg)](https://gitter.im/neotypes-neotypes/Lobby)
 [![Scala Steward badge](https://img.shields.io/badge/Scala_Steward-helping-blue.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=)](https://scala-steward.org)
 
@@ -16,17 +16,17 @@ For early adopters:
 
 |Supports Scala 2.12 and 2.13||
 | ----------------------------------------- |:--------------|
-|`"com.dimafeng" %% "neotypes" % version`|core functionality. Supports `scala.concurrent.Future`.|
-|`"com.dimafeng" %% "neotypes-cats-effect" % version`|`cats.effect.Async[F]` implementation.|
-|`"com.dimafeng" %% "neotypes-monix" % version`|`monix.eval.Task` implementation.|
-|`"com.dimafeng" %% "neotypes-zio" % version`|`zio.Task` implementation.|
-|`"com.dimafeng" %% "neotypes-akka-stream" % version`|result streaming for Akka Streams.|
-|`"com.dimafeng" %% "neotypes-fs2-stream" % version`|result streaming for FS2.|
-|`"com.dimafeng" %% "neotypes-monix-stream" % version`|result streaming for Monix Observables.|
-|`"com.dimafeng" %% "neotypes-zio-stream" % version`|result streaming for ZIO ZStreams.|
-|`"com.dimafeng" %% "neotypes-refined" % version`|support to insert and retrieve refined values.|
-|`"com.dimafeng" %% "neotypes-cats-data" % version`|support to insert and retrieve `cats.data` values.|
-|`"com.dimafeng" %% "neotypes-enumeratum" % version`|support to insert and retrieve Enumeratum enums.|
+|`"io.github.neotypes" %% "neotypes-core" % version`|core functionality. Supports `scala.concurrent.Future`.|
+|`"io.github.neotypes" %% "neotypes-cats-effect" % version`|`cats.effect.Async[F]` implementation.|
+|`"io.github.neotypes" %% "neotypes-monix" % version`|`monix.eval.Task` implementation.|
+|`"io.github.neotypes" %% "neotypes-zio" % version`|`zio.Task` implementation.|
+|`"io.github.neotypes" %% "neotypes-akka-stream" % version`|result streaming for Akka Streams.|
+|`"io.github.neotypes" %% "neotypes-fs2-stream" % version`|result streaming for FS2.|
+|`"io.github.neotypes" %% "neotypes-monix-stream" % version`|result streaming for Monix Observables.|
+|`"io.github.neotypes" %% "neotypes-zio-stream" % version`|result streaming for ZIO ZStreams.|
+|`"io.github.neotypes" %% "neotypes-refined" % version`|support to insert and retrieve refined values.|
+|`"io.github.neotypes" %% "neotypes-cats-data" % version`|support to insert and retrieve `cats.data` values.|
+|`"io.github.neotypes" %% "neotypes-enumeratum" % version`|support to insert and retrieve Enumeratum enums.|
 
 **Scala lightweight, type-safe, asynchronous driver (not opinionated on side-effect implementation) for neo4j**.
 

--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,7 @@ ThisBuild / scmInfo ~= {
 // Global settings.
 ThisBuild / scalaVersion := "2.12.14"
 ThisBuild / crossScalaVersions := Seq("2.12.14", "2.13.6")
-ThisBuild / organization := "com.dimafeng"
+ThisBuild / organization := "io.github.neotypes"
 ThisBuild / versionScheme := Some("semver-spec")
 
 def removeScalacOptionsInTest(scalaVersion: String) =
@@ -124,7 +124,7 @@ lazy val root = (project in file("."))
 lazy val core = (project in file("core"))
   .settings(commonSettings)
   .settings(
-    name := "neotypes",
+    name := "neotypes-core",
     libraryDependencies ++=
       PROVIDED(
         "org.neo4j.driver" % "neo4j-java-driver" % neo4jDriverVersion

--- a/site/src/main/mdoc/changelog.md
+++ b/site/src/main/mdoc/changelog.md
@@ -7,6 +7,59 @@ position: 100
 
 # Changelog
 
+## v0.18.0 _(2021-06-xx)_
+
+### Update organization id ([#359](https://github.com/neotypes/neotypes/pull/359){:target="_blank"})
+
+This is the first version to be released to `io.github.neotypes` rather than to `com.dimafeng`
+
+This releases also changed the name of the **core** module from just `neotypes` to `neotypes-core`
+
+### Ensuring all casting errors during mapping are encapsulated in a NeotypesException ([#345](https://github.com/neotypes/neotypes/pull/345){:target="_blank"})
+
+This is basically a bug fix that ensures that any exception thrown
+during the _"casting"_ of **Neo4j** values to **Scala** ones
+are catch by the underlying `ValueMapper`
+and wrapped in the optional cause of a `neotypes.exceptions.IncoercibleException`
+
+We also removed `neotypes.exceptions.ConversionException`
+and replaced its only usage with a `neotypes.exceptions.IncoercibleException`
+for consistency.
+
+### Add cypher interpolation of DeferredQueryBuilder ([#344](https://github.com/neotypes/neotypes/pull/344){:target="_blank"})
+
+We added the capability to embedded `DeferredQueryBuilders` inside other queries,
+which helps a lot to share and reuse common _(sub)_ queries.
+
+Which means that the following examples now compile out-of-the-box and behave as expected.
+
+```scala mdoc:compile-only
+import neotypes.implicits.syntax.cypher._
+
+// Two sub-queries.
+val subQuery1Param = 1
+val subQuery1 = c"user.id = ${subQuery1Param}"
+val subQuery2Param = "Luis"
+val subQuery2 = c"user.name = ${subQuery2Param}"
+val query1 = c"MATCH (user: User) WHERE ${subQuery1} OR ${subQuery2} RETURN user"
+
+// Sub.query with a sub-query.
+val subSubQueryParam = 1
+val subSubQuery = c"user.id = ${subSubQueryParam}"
+val subQuery = c"""${subSubQuery} OR user.name = "Luis""""
+val query2 = c"MATCH (user: User) WHERE ${subQuery} RETURN user"
+```
+
+> Special thanks to @tjarvstrand for all the hard work in this PR!
+
+### Make default transaction config configurable ([#341](https://github.com/neotypes/neotypes/pull/341){:target="_blank"})
+
+We added a new `withTransactionConfig` method to the `Driver` interface,
+this method can be used to crate a new `Driver[F]` whose default `TransactionConfig`
+will be the one passed to the previous method.
+
+This is very useful when you need to use a custom config across all the application, or for tests.
+
 ## v0.17.0 _(2021-04-04)_
 
 ### Adding the enumeratum module ([#291](https://github.com/neotypes/neotypes/pull/291){:target="_blank"})

--- a/site/src/main/mdoc/index.md
+++ b/site/src/main/mdoc/index.md
@@ -10,7 +10,7 @@ position: 0
 > neotype - a type specimen that is selected subsequent to the description of a species to replace a preexisting type that has been lost or destroyed.
 
 [![Build Status](https://travis-ci.org/neotypes/neotypes.svg?branch=main)](https://travis-ci.org/neotypes/neotypes)
-[![Maven Central](https://img.shields.io/maven-central/v/com.dimafeng/neotypes_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.dimafeng/neotypes_2.12)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.neotypes/neotypes-core_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/io.github.neotypes/neotypes-core_2.12)
 [![Gitter Chat](https://badges.gitter.im/neotypes-neotypes/Lobby.svg)](https://gitter.im/neotypes-neotypes/Lobby)
 [![Scala Steward badge](https://img.shields.io/badge/Scala_Steward-helping-blue.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=)](https://scala-steward.org)
 
@@ -32,17 +32,17 @@ The project aims to provide seamless integration with most popular scala infrast
 
 {:.table}
 | ----------------------------------------- |:--------------|
-|`"com.dimafeng" %% "neotypes" % version`|core functionality. Supports `scala.concurrent.Future`.|
-|`"com.dimafeng" %% "neotypes-cats-effect" % version`|`cats.effect.Async[F]` implementation.|
-|`"com.dimafeng" %% "neotypes-monix" % version`|`monix.eval.Task` implementation.|
-|`"com.dimafeng" %% "neotypes-zio" % version`|`zio.Task` implementation.|
-|`"com.dimafeng" %% "neotypes-akka-stream" % version`|result streaming for Akka Streams.|
-|`"com.dimafeng" %% "neotypes-fs2-stream" % version`|result streaming for FS2.|
-|`"com.dimafeng" %% "neotypes-monix-stream" % version`|result streaming for Monix Observables.|
-|`"com.dimafeng" %% "neotypes-zio-stream" % version`|result streaming for ZIO ZStreams.|
-|`"com.dimafeng" %% "neotypes-refined" % version`|support to insert and retrieve refined values.|
-|`"com.dimafeng" %% "neotypes-cats-data" % version`|support to insert and retrieve `cats.data` values.|
-|`"com.dimafeng" %% "neotypes-enumeratum" % version`|support to insert and retrieve Enumeratum enums.|
+|`"io.github.neotypes" %% "neotypes-core" % version`|core functionality. Supports `scala.concurrent.Future`.|
+|`"io.github.neotypes" %% "neotypes-cats-effect" % version`|`cats.effect.Async[F]` implementation.|
+|`"io.github.neotypes" %% "neotypes-monix" % version`|`monix.eval.Task` implementation.|
+|`"io.github.neotypes" %% "neotypes-zio" % version`|`zio.Task` implementation.|
+|`"io.github.neotypes" %% "neotypes-akka-stream" % version`|result streaming for Akka Streams.|
+|`"io.github.neotypes" %% "neotypes-fs2-stream" % version`|result streaming for FS2.|
+|`"io.github.neotypes" %% "neotypes-monix-stream" % version`|result streaming for Monix Observables.|
+|`"io.github.neotypes" %% "neotypes-zio-stream" % version`|result streaming for ZIO ZStreams.|
+|`"io.github.neotypes" %% "neotypes-refined" % version`|support to insert and retrieve refined values.|
+|`"io.github.neotypes" %% "neotypes-cats-data" % version`|support to insert and retrieve `cats.data` values.|
+|`"io.github.neotypes" %% "neotypes-enumeratum" % version`|support to insert and retrieve Enumeratum enums.|
 
 ## Showcase
 


### PR DESCRIPTION
This PR updates the organization id so we can do the following `0.18.0` release under `io.github.neotypes`

It also adds the **Changelog** for that release.