### PR TITLE
Reverting the neo4j#797 workaround

### DIFF
--- a/site/src/main/mdoc/changelog.md
+++ b/site/src/main/mdoc/changelog.md
@@ -7,6 +7,16 @@ position: 100
 
 # Changelog
 
+## v0.18.3 _(2021-06-25)_
+
+### Reverting the neo4j#797 workaround ([#364](https://github.com/neotypes/neotypes/pull/364){:target="_blank"})
+
+This is just an internal code refactor thanks to a bug fix in the underlying **Java** driver.
+
+However, this refactor implies that users need to update their underlying **Java** driver
+to the latest patch versions.<br>
+As of the writing date: `4.3.2`, `4.2.7` & `4.1.4`; `4.0` seems to be not longer maintained.
+
 ## v0.18.2 _(2021-06-16)_
 
 ### Don't override driver's tx-config from DeferredQuery ([#362](https://github.com/neotypes/neotypes/pull/362){:target="_blank"})

--- a/site/src/main/mdoc/index.md
+++ b/site/src/main/mdoc/index.md
@@ -101,3 +101,9 @@ Await.ready(driver.close, 1.second)
 
 For info on the compatibility with **Java** runtimes or **Neo4j** servers,
 please check the the [**Java** driver docs](https://github.com/neo4j/neo4j-java-driver).
+
+> **Note:** Since `0.18.3` **neotypes** not longer supports the
+> `4.0` series of the **Java** driver,
+> it also now requires the latest patch version of the
+> `4.1`, `4.2` or `4.3` series.<br>
+> See the changelog and the associated PR for details.


### PR DESCRIPTION
https://github.com/neo4j/neo4j-java-driver/pull/932 fixed https://github.com/neo4j/neo4j-java-driver/issues/797

Thanks to that we can revert the ugly workaround we had and rather use the pretty code we all liked.

Of course, we need to wait for a proper `4.3.2` release of the **neo4j-java-driver** before we can merge this one.
However, I wanted to open this PR right now to discuss something.

Since we do not enforce the version of the driver since it is provided and then it is the responsibility of our users to upgrade the driver to the latest patch version for this code to work. If they update to a newer version of **neotypes** without upgrading the driver then they will have runtime errors; which is not nice.

I believe that we must, at least, be extremely explicit about it somewhere in the docs.
But maybe we may also keep the previous workaround just for compatibility? Since we are not still at `1.0.0` I think its fine to just require the latest versions of the underlying driver; especially since it seems they will backport it to previous versions like `4.2` and `4.1` so users would only need to update a patch version, not a minor version which may be more problematic.

What do other folks think about this?
@dimafeng @tjarvstrand @iRevive @geoffjohn11